### PR TITLE
Add permission fix and .env backup steps in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -48,7 +48,7 @@ jobs:
       with:
         submodules: recursive
         fetch-depth: 0
-        # Disable workspace cleaning to preserve .env files and permission fixes from previous runs
+        # Disable workspace cleaning to preserve permission fixes from previous runs
         clean: false
     
     - name: Update extension submodules to tracked branches


### PR DESCRIPTION
This pull request updates the deployment workflow to improve handling of file permissions and environment files during the GitHub Actions deployment process. The main goal is to prevent issues caused by root-owned files and ensure `.env` files are preserved across the `checkout` step.

**Workflow improvements:**

* Added a step before `actions/checkout` to fix permissions on root-owned files and remove `__pycache__` directories, preventing permission errors and stale bytecode issues. [[1]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R31-R55) [[2]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R116-R140)
* Implemented backup of all `.env` files before the repository is checked out, ensuring sensitive environment configurations are not lost. [[1]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R31-R55) [[2]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R116-R140)
* Set the `clean: false` option in the `actions/checkout` step to avoid deleting untracked files, which helps preserve backups and other important files. [[1]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R31-R55) [[2]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R116-R140)
* Added a step after `actions/checkout` to restore `.env` files from their backups, maintaining environment consistency throughout the workflow. [[1]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R31-R55) [[2]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R116-R140)