### PR TITLE
chore: ignore extension build artifacts in parent repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,14 @@ dmypy.json
 
 # Never ignore .gitkeep files
 !**/.gitkeep
+
+# Extension build artifacts (submodules handle their own .gitignore)
+extensions/*/web-*/node_modules/
+extensions/*/web-*/.pnpm-store/
+extensions/*/web-*/.vite/
+extensions/*/web-*/dist/
+extensions/*/api-*/__pycache__/
+extensions/*/api-*/.venv/
+extensions/*/api-*/.pytest_cache/
+extensions/*/api-*/coverage/
+extensions/*/api-*/*.db


### PR DESCRIPTION
- Add patterns to ignore node_modules, .pnpm-store, .vite, dist for web extensions
- Add patterns to ignore __pycache__, .venv, .pytest_cache, coverage, *.db for api extensions
- Prevents build artifacts from showing as untracked files