### PR TITLE
Refactor OIDC authentication with state cookie CSRF protection

### DIFF
--- a/api-nei/app/api/api_v1/auth/oidc.py
+++ b/api-nei/app/api/api_v1/auth/oidc.py
@@ -1,44 +1,81 @@
 """
 OIDC/OpenID Connect authentication endpoints for Authentik integration.
 
-This module provides OAuth2/OIDC authentication flow to integrate with
-the Authentik identity provider running in the infrastructure.
+Flow
+----
+Login:
+  1. GET /auth/oidc/login  →  redirect to Authentik with a signed state cookie
+  2. GET /auth/oidc/callback  →  verify state, exchange code, upsert user, return platform JWT
+
+Account linking (allows existing password users to link to Authentik SSO):
+  1. POST /auth/oidc/link  →  redirect to Authentik with signed state cookie (contains user_id)
+  2. GET /auth/oidc/link-callback  →  verify state, set authentik_sub on existing user
+
+State / CSRF protection
+-----------------------
+A random nonce is generated on /oidc/login and /oidc/link.  It is:
+  - Sent as the `state` query parameter to Authentik (so Authentik echoes it back).
+  - Stored in a short-lived, HttpOnly, signed cookie (using itsdangerous).
+
+On callback the cookie is read, the signature is verified, and the nonce is
+compared to the `state` parameter returned by Authentik.  Any mismatch or
+missing cookie is rejected with 401.
+
+Authentik property-mapping requirements
+----------------------------------------
+The userinfo endpoint must expose these custom claims (configure via
+Authentik → Customisation → Property Mappings → Scope Mappings):
+
+  Scope: nei_nmec
+    Expression:  return {"nmec": request.user.attributes.get("nmec")}
+
+  Scope: nei_iupi
+    Expression:  return {"iupi": request.user.attributes.get("iupi")}
+
+  Scope: nei_scopes
+    Expression:  return {"scopes": request.user.attributes.get("platform_scopes", ["default"])}
+
+These scopes must be added to the nei-platform Application → Protocol Settings.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
-from fastapi.responses import RedirectResponse
-from sqlalchemy.orm import Session
-from authlib.integrations.starlette_client import OAuth, OAuthError
-from loguru import logger
+import secrets
 from typing import Optional
 
+import httpx
+from authlib.integrations.starlette_client import OAuth
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi.responses import RedirectResponse
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from app import crud
 from app.api import deps
 from app.core.config import settings
 from app.models.user import User
 from app.models.user.user_email import UserEmail
-from app.schemas.user import UserCreate, ScopeEnum
-from app import crud
-from ._deps import Token, generate_response, verify_token, AuthData
+from app.schemas.user import ScopeEnum, UserCreate
+
+from ._deps import AuthData, Token, generate_response, private_key, verify_token
 
 router = APIRouter()
 
-# Initialize OAuth client
+
+# ---------------------------------------------------------------------------
+# OAuth client setup
+# ---------------------------------------------------------------------------
+
 oauth = OAuth()
 
 if settings.OIDC_ENABLED:
-    # For development: disable SSL verification if needed
-    # In production, ensure proper SSL certificates are configured
-    import httpx
-    
-    client_kwargs = {
+    client_kwargs: dict = {
         "scope": " ".join(settings.OIDC_SCOPES),
         "token_endpoint_auth_method": "client_secret_post",
     }
-    
-    # Disable SSL verification for development/self-signed certs
     if not settings.PRODUCTION:
+        # Allow self-signed certs in development
         client_kwargs["verify"] = False
-    
+
     oauth.register(
         name="authentik",
         client_id=settings.OIDC_CLIENT_ID,
@@ -48,238 +85,310 @@ if settings.OIDC_ENABLED:
     )
 
 
+# ---------------------------------------------------------------------------
+# State cookie helpers
+# ---------------------------------------------------------------------------
+
+_STATE_COOKIE = "oauth_state"
+_STATE_MAX_AGE = 600  # 10 minutes — plenty for the Authentik round-trip
+
+
+def _signer() -> URLSafeTimedSerializer:
+    # Reuse the JWT private key as the HMAC secret — already confidential,
+    # available on startup, consistent across restarts and replicas.
+    return URLSafeTimedSerializer(private_key)
+
+
+def _set_state_cookie(
+    response: Response,
+    nonce: str,
+    *,
+    redirect_to: Optional[str] = None,
+    user_id: Optional[int] = None,
+) -> None:
+    """Sign and store OAuth state in an HttpOnly cookie."""
+    payload: dict = {"n": nonce}
+    if redirect_to:
+        payload["r"] = redirect_to
+    if user_id is not None:
+        payload["u"] = user_id
+    response.set_cookie(
+        _STATE_COOKIE,
+        _signer().dumps(payload),
+        httponly=True,
+        secure=settings.PRODUCTION,
+        samesite="lax",
+        max_age=_STATE_MAX_AGE,
+    )
+
+
+def _verify_and_pop_state_cookie(request: Request, response: Response, nonce: str) -> dict:
+    """Read, verify and clear the state cookie.  Raises 401 on any failure."""
+    cookie_val = request.cookies.get(_STATE_COOKIE)
+    # Always clear the cookie regardless of outcome (prevent replay)
+    response.delete_cookie(_STATE_COOKIE, httponly=True, samesite="lax")
+
+    if not cookie_val:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Missing OAuth state cookie")
+
+    try:
+        payload = _signer().loads(cookie_val, max_age=_STATE_MAX_AGE)
+    except SignatureExpired:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "OAuth state expired — please try again")
+    except BadSignature:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid OAuth state")
+
+    if payload.get("n") != nonce:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "OAuth state mismatch")
+
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Authentik metadata / token exchange helpers
+# ---------------------------------------------------------------------------
+
+async def _load_endpoints() -> tuple[str, str]:
+    """Return (token_endpoint, userinfo_endpoint) from Authentik discovery."""
+    meta = await oauth.authentik.load_server_metadata()
+    return meta["token_endpoint"], meta["userinfo_endpoint"]
+
+
+async def _exchange_code(
+    code: str,
+    redirect_uri: str,
+    token_endpoint: str,
+    userinfo_endpoint: str,
+) -> dict:
+    """Exchange an authorization code for userinfo.  Returns the userinfo dict."""
+    verify_ssl = settings.PRODUCTION
+    async with httpx.AsyncClient(verify=verify_ssl) as client:
+        token_resp = await client.post(
+            token_endpoint,
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "client_id": settings.OIDC_CLIENT_ID,
+                "client_secret": settings.OIDC_CLIENT_SECRET,
+            },
+        )
+        token_resp.raise_for_status()
+        token = token_resp.json()
+
+        userinfo_resp = await client.get(
+            userinfo_endpoint,
+            headers={"Authorization": f"Bearer {token['access_token']}"},
+        )
+        userinfo_resp.raise_for_status()
+        return userinfo_resp.json()
+
+
+# ---------------------------------------------------------------------------
+# User upsert
+# ---------------------------------------------------------------------------
+
+def _parse_scopes(raw) -> list[str]:
+    """Normalise scopes from an OIDC claim (list or space-separated string)."""
+    if isinstance(raw, str):
+        items = raw.split()
+    elif isinstance(raw, list):
+        items = raw
+    else:
+        return ["default"]
+
+    valid = []
+    for s in items:
+        try:
+            valid.append(ScopeEnum(s.strip().lower()).value)
+        except ValueError:
+            logger.warning(f"Unknown scope from Authentik: {s!r} — skipping")
+    return valid or ["default"]
+
+
 def get_or_create_user_from_oidc(db: Session, userinfo: dict) -> User:
-    """
-    Get existing user or create new user from OIDC userinfo.
+    """Get or create a platform user from Authentik userinfo, syncing data on every login.
 
-    This function handles both scenarios:
-    1. User already exists with authentik_sub - return existing user
-    2. User doesn't exist - create new user with data from Authentik
+    Lookup order:
+      1. By authentik_sub  — fast path for already-linked users
+      2. By email          — auto-link accounts created during the migration
 
-    **Parameters**
-    * `db`: SQLAlchemy database session
-    * `userinfo`: OIDC userinfo dict containing user claims
-
-    **Returns**
-    * User object
+    On every login, name / surname / nmec / iupi / scopes are synced from
+    Authentik so the platform DB stays consistent with Authentik as the IdP.
     """
     authentik_sub = userinfo.get("sub")
     email = userinfo.get("email")
 
     if not authentik_sub or not email:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid OIDC response: missing sub or email",
+            status.HTTP_400_BAD_REQUEST,
+            "Invalid OIDC response: missing sub or email",
         )
 
-    # Try to find user by authentik_sub first
-    user = db.query(User).filter(User.authentik_sub == authentik_sub).first()
+    # Parse claims
+    name_parts = userinfo.get("name", "").split(" ", 1)
+    name = (name_parts[0] or "").strip()[:20] or "User"
+    surname = (name_parts[1] if len(name_parts) > 1 else "").strip()[:20]
+    nmec: Optional[int] = userinfo.get("nmec")
+    iupi: Optional[str] = userinfo.get("iupi")
+    scopes = _parse_scopes(userinfo.get("scopes", []))
+
+    # 1. Look up by authentik_sub
+    user: Optional[User] = db.query(User).filter(User.authentik_sub == authentik_sub).first()
+
+    if not user:
+        # 2. Look up by email — covers migrated users who haven't logged in via OIDC yet
+        email_row = db.query(UserEmail).filter(UserEmail.email == email).first()
+        if email_row:
+            user = db.query(User).filter(User.id == email_row.user_id).first()
+            if user:
+                logger.info(f"Auto-linking user {user.id} to Authentik sub {authentik_sub!r}")
 
     if user:
-        logger.info(f"Found existing user with authentik_sub: {user.id}")
-        return user
+        # Sync mutable fields — Authentik is the source of truth after migration
+        changed = False
 
-    # Try to find user by email (for account linking)
-    user_email = db.query(UserEmail).filter(UserEmail.email == email).first()
+        def _set(attr: str, value) -> None:
+            nonlocal changed
+            if value is not None and getattr(user, attr) != value:
+                setattr(user, attr, value)
+                changed = True
 
-    if user_email:
-        # User exists but not linked to Authentik - link it now
-        user = db.query(User).filter(User.id == user_email.user_id).first()
-        if user:
-            logger.info(f"Linking existing user {user.id} to Authentik sub: {authentik_sub}")
-            user.authentik_sub = authentik_sub
+        _set("authentik_sub", authentik_sub)
+        _set("name", name)
+        _set("surname", surname)
+        _set("nmec", nmec)
+        _set("iupi", iupi)
+        if scopes and set(user.scopes or []) != set(scopes):
+            user.scopes = scopes
+            changed = True
+
+        if changed:
             db.commit()
             db.refresh(user)
-            return user
 
-    # User doesn't exist - create new one
-    logger.info(f"Creating new user from Authentik: {email}")
+        logger.info(f"OIDC login: user {user.id} ({'synced' if changed else 'unchanged'})")
+        return user
 
-    # Extract user data from OIDC claims
-    name_parts = userinfo.get("name", "").split(" ", 1)
-    name = name_parts[0] if name_parts else userinfo.get("preferred_username", "User")
-    surname = name_parts[1] if len(name_parts) > 1 else ""
-
-    # Get NEI-specific attributes
-    nmec = userinfo.get("nmec")
-    iupi = userinfo.get("iupi")
-    scopes_data = userinfo.get("scopes", ["DEFAULT"])
-
-    # Parse scopes - could be a list or space-separated string
-    if isinstance(scopes_data, str):
-        scopes = scopes_data.split(" ")
-    else:
-        scopes = scopes_data if isinstance(scopes_data, list) else ["DEFAULT"]
-
-    # Validate scopes against enum (normalize to lowercase first)
-    valid_scopes = []
-    for scope in scopes:
-        try:
-            # Normalize to lowercase for comparison
-            normalized_scope = scope.strip().lower()
-            valid_scopes.append(ScopeEnum(normalized_scope).value)
-        except ValueError:
-            logger.warning(f"Invalid scope from Authentik: {scope}, skipping")
-
-    if not valid_scopes:
-        valid_scopes = ["default"]
-
-    # Create user object
-    user_create = UserCreate(
-        name=name[:20] if name else "User",  # Respect max length
-        surname=surname[:20] if surname else "",
-        email=email,
-        password=None,  # No password for OIDC users
-        scopes=valid_scopes,
-        nmec=nmec,
-        iupi=iupi,
+    # 3. New user — create from OIDC data
+    logger.info(f"Creating new user from Authentik: {email!r}")
+    user = crud.user.create(
+        db=db,
+        obj_in=UserCreate(
+            name=name,
+            surname=surname,
+            email=email,
+            password=None,
+            scopes=scopes,
+            nmec=nmec,
+            iupi=iupi,
+        ),
+        active=True,
     )
-
-    # Create user in database
-    user = crud.user.create(db=db, obj_in=user_create, active=True)
-
-    # Link to Authentik
     user.authentik_sub = authentik_sub
     db.commit()
     db.refresh(user)
-
-    logger.info(f"Created new user {user.id} from Authentik")
+    logger.info(f"Created user {user.id} from Authentik")
     return user
 
 
-@router.get(
-    "/oidc/login",
-    responses={
-        503: {"description": "OIDC authentication is disabled"},
-    },
-)
-async def oidc_login(request: Request, redirect_to: Optional[str] = None):
-    """
-    Initiate OIDC authentication flow.
+# ---------------------------------------------------------------------------
+# Guard
+# ---------------------------------------------------------------------------
 
-    Redirects the user to Authentik for authentication.
-
-    **Query Parameters**
-    * `redirect_to`: Optional URL to redirect to after successful login
-
-    **Returns**
-    * Redirect response to Authentik authorization endpoint
-    """
+def _require_oidc() -> None:
     if not settings.OIDC_ENABLED:
         raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="OIDC authentication is not enabled",
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "OIDC authentication is not enabled",
         )
 
-    # Build callback URL
-    callback_url = str(request.url_for("oidc_callback"))
-    if redirect_to:
-        callback_url = f"{callback_url}?redirect_to={redirect_to}"
 
-    # Manually build authorization URL (avoiding session dependency)
-    auth_url = await oauth.authentik.create_authorization_url(callback_url)
-    
-    return RedirectResponse(url=auth_url["url"])
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/oidc/login",
+    responses={503: {"description": "OIDC authentication is disabled"}},
+)
+async def oidc_login(
+    request: Request,
+    response: Response,
+    redirect_to: Optional[str] = None,
+):
+    """Initiate OIDC login: redirect to Authentik.
+
+    **Query Parameters**
+    * `redirect_to`: Optional URL the frontend should navigate to after login
+      (returned in the callback JSON so the client can act on it).
+    """
+    _require_oidc()
+
+    nonce = secrets.token_urlsafe(32)
+    redirect_uri = str(request.url_for("oidc_callback"))
+    await oauth.authentik.load_server_metadata()
+    auth_url_data = await oauth.authentik.create_authorization_url(redirect_uri, state=nonce)
+    auth_url = auth_url_data["url"]
+
+    redirect_response = RedirectResponse(url=auth_url)
+    _set_state_cookie(redirect_response, nonce, redirect_to=redirect_to)
+    return redirect_response
 
 
 @router.get(
     "/oidc/callback",
     response_model=Token,
     responses={
-        401: {"description": "Authentication failed"},
+        401: {"description": "Authentication failed or invalid state"},
         503: {"description": "OIDC authentication is disabled"},
     },
 )
 async def oidc_callback(
     request: Request,
+    response: Response,
     code: str,
-    state: Optional[str] = None,
+    state: str,
     db: Session = Depends(deps.get_db),
-    redirect_to: Optional[str] = None,
 ):
+    """Handle Authentik callback: verify state, exchange code, return platform tokens.
+
+    On success the response body is `{access_token, token_type}` (same as
+    password login).  If `redirect_to` was passed to `/oidc/login`, it is
+    included in the response as `redirect_to` so the frontend can navigate.
     """
-    Handle OIDC callback from Authentik.
+    _require_oidc()
 
-    Exchanges authorization code for tokens, retrieves user info,
-    and creates/updates user in the platform database.
-
-    **Query Parameters**
-    * `code`: Authorization code from Authentik (automatic)
-    * `state`: State parameter for CSRF protection (automatic)
-    * `redirect_to`: Optional URL to redirect to after login
-
-    **Returns**
-    * Token response with access_token and refresh cookie
-    """
-    if not settings.OIDC_ENABLED:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="OIDC authentication is not enabled",
-        )
+    state_payload = _verify_and_pop_state_cookie(request, response, state)
+    redirect_to: Optional[str] = state_payload.get("r")
 
     try:
-        # Load server metadata if not already loaded
-        await oauth.authentik.load_server_metadata()
-        
-        # Manually exchange code for token using httpx
-        token_endpoint = oauth.authentik.server_metadata["token_endpoint"]
-        
-        # Use same SSL verification setting as OAuth client
-        verify_ssl = settings.PRODUCTION
-        
-        async with httpx.AsyncClient(verify=verify_ssl) as client:
-            # Exchange authorization code for tokens
-            token_response = await client.post(
-                token_endpoint,
-                data={
-                    "grant_type": "authorization_code",
-                    "code": code,
-                    "redirect_uri": str(request.url_for("oidc_callback")),
-                    "client_id": settings.OIDC_CLIENT_ID,
-                    "client_secret": settings.OIDC_CLIENT_SECRET,
-                },
-            )
-            token_response.raise_for_status()
-            token = token_response.json()
-
-            # Get user information from userinfo endpoint
-            userinfo_endpoint = oauth.authentik.server_metadata["userinfo_endpoint"]
-            userinfo_response = await client.get(
-                userinfo_endpoint,
-                headers={"Authorization": f"Bearer {token['access_token']}"},
-            )
-            userinfo_response.raise_for_status()
-            userinfo = userinfo_response.json()
-
+        token_endpoint, userinfo_endpoint = await _load_endpoints()
+        redirect_uri = str(request.url_for("oidc_callback"))
+        userinfo = await _exchange_code(code, redirect_uri, token_endpoint, userinfo_endpoint)
         logger.debug(f"OIDC userinfo: {userinfo}")
 
-        # Create or get user from OIDC data
         user = get_or_create_user_from_oidc(db, userinfo)
+        token_response = generate_response(db, user)
 
-        # Generate platform JWT tokens using existing infrastructure
-        response = generate_response(db, user)
+        if redirect_to:
+            # Surface redirect_to so the frontend SPA can navigate after it
+            # receives and stores the token.
+            token_response.headers["X-Redirect-To"] = redirect_to
 
-        # If redirect_to provided, could handle redirect here
-        # For API, we just return the tokens
-        return response
+        return token_response
 
-    except OAuthError as e:
-        logger.error(f"OAuth error during OIDC callback: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"Authentication failed: {str(e)}",
-        )
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"Unexpected error during OIDC callback: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Authentication failed due to server error",
-        )
+        logger.error(f"OIDC callback error: {e}")
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Authentication failed")
 
 
 @router.post(
     "/oidc/link",
     responses={
+        400: {"description": "Account already linked"},
         401: {"description": "Not authenticated"},
         503: {"description": "OIDC authentication is disabled"},
     },
@@ -289,138 +398,82 @@ async def start_oidc_link(
     auth_data: AuthData = Depends(verify_token),
     db: Session = Depends(deps.get_db),
 ):
+    """Start account linking: redirect authenticated user to Authentik.
+
+    Allows users who registered with a password to link their account to
+    Authentik so they can use SSO in the future.
     """
-    Start account linking flow for existing users.
+    _require_oidc()
 
-    Allows users who registered with password to link their account
-    to Authentik for SSO access.
-
-    **Returns**
-    * Redirect URL to Authentik for account linking
-    """
-    if not settings.OIDC_ENABLED:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="OIDC authentication is not enabled",
-        )
-
-    # Get current user from auth_data
-    user = db.query(User).filter(User.id == auth_data.user_id).first()
+    user = db.query(User).filter(User.id == auth_data.sub).first()
     if not user:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="User not found",
-        )
-
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "User not found")
     if user.authentik_sub:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Account is already linked to Authentik",
-        )
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Account is already linked to Authentik")
 
-    # Create state token containing user_id for verification in callback
-    # Note: In production, this should be a signed JWT or stored in Redis
-    state = f"link:{user.id}"
+    nonce = secrets.token_urlsafe(32)
+    redirect_uri = str(request.url_for("oidc_link_callback"))
+    await oauth.authentik.load_server_metadata()
+    auth_url_data = await oauth.authentik.create_authorization_url(redirect_uri, state=nonce)
+    auth_url = auth_url_data["url"]
 
-    callback_url = request.url_for("oidc_link_callback")
-    callback_url = f"{callback_url}?state={state}"
-
-    return await oauth.authentik.authorize_redirect(request, callback_url)
+    link_response = RedirectResponse(url=auth_url)
+    _set_state_cookie(link_response, nonce, user_id=auth_data.sub)
+    return link_response
 
 
 @router.get(
     "/oidc/link-callback",
     responses={
-        401: {"description": "Invalid state or authentication failed"},
+        401: {"description": "Invalid or expired state"},
+        409: {"description": "Authentik account already linked to another user"},
         503: {"description": "OIDC authentication is disabled"},
     },
 )
 async def oidc_link_callback(
     request: Request,
+    response: Response,
+    code: str,
     state: str,
     db: Session = Depends(deps.get_db),
 ):
-    """
-    Complete account linking flow.
+    """Complete account linking."""
+    _require_oidc()
 
-    Links an existing platform user account to their Authentik identity.
+    state_payload = _verify_and_pop_state_cookie(request, response, state)
+    user_id = state_payload.get("u")
+    if user_id is None:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid state: missing user context")
 
-    **Query Parameters**
-    * `state`: State token containing user_id (automatic)
-    * `code`: Authorization code from Authentik (automatic)
-
-    **Returns**
-    * Success message
-    """
-    if not settings.OIDC_ENABLED:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="OIDC authentication is not enabled",
-        )
-
-    # Verify state and extract user_id
-    if not state.startswith("link:"):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid state parameter",
-        )
-
-    try:
-        user_id = int(state.split(":")[1])
-    except (IndexError, ValueError):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid state parameter",
-        )
-
-    # Get user
     user = db.query(User).filter(User.id == user_id).first()
     if not user:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="User not found",
-        )
-
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "User not found")
     if user.authentik_sub:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Account is already linked",
-        )
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Account is already linked")
 
     try:
-        # Exchange authorization code for tokens
-        token = await oauth.authentik.authorize_access_token(request)
-        userinfo = token.get("userinfo") or await oauth.authentik.userinfo(token=token)
+        token_endpoint, userinfo_endpoint = await _load_endpoints()
+        redirect_uri = str(request.url_for("oidc_link_callback"))
+        userinfo = await _exchange_code(code, redirect_uri, token_endpoint, userinfo_endpoint)
 
         authentik_sub = userinfo.get("sub")
         if not authentik_sub:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Invalid OIDC response",
-            )
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, "Invalid OIDC response: missing sub")
 
-        # Check if this Authentik account is already linked to another user
         existing = db.query(User).filter(User.authentik_sub == authentik_sub).first()
         if existing:
             raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="This Authentik account is already linked to another user",
+                status.HTTP_409_CONFLICT,
+                "This Authentik account is already linked to another user",
             )
 
-        # Link the accounts
         user.authentik_sub = authentik_sub
         db.commit()
+        logger.info(f"Linked user {user.id} to Authentik sub {authentik_sub!r}")
+        return {"status": "success", "message": "Account successfully linked to Authentik"}
 
-        logger.info(f"Successfully linked user {user.id} to Authentik sub: {authentik_sub}")
-
-        return {
-            "status": "success",
-            "message": "Account successfully linked to Authentik",
-        }
-
-    except OAuthError as e:
-        logger.error(f"OAuth error during account linking: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"Authentication failed: {str(e)}",
-        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"OIDC link-callback error: {e}")
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Account linking failed")

--- a/scripts/migrate_users_to_authentik.py
+++ b/scripts/migrate_users_to_authentik.py
@@ -183,6 +183,21 @@ class AuthentikAPI:
         }
         return self._post("/core/users/", json=payload)
 
+    def send_verification_email(self, authentik_pk: int) -> str:
+        """
+        Trigger Authentik's recovery flow for the user, which sends them an
+        email with a link to verify their address.
+
+        The link goes through whichever recovery flow is configured in Authentik.
+        To make this purely an email verification (no forced password change),
+        configure the recovery flow in Authentik to include an Email Verification
+        stage but no Password Change stage — or make the password stage optional.
+
+        Returns the recovery link URL (also sent by email if an email stage is set up).
+        """
+        result = self._post(f"/core/users/{authentik_pk}/recovery/", json={})
+        return result.get("link", "")
+
 
 # ---------------------------------------------------------------------------
 # Authentik DB helpers
@@ -217,6 +232,7 @@ def migrate_user(
     api: AuthentikAPI,
     authentik_conn,
     dry_run: bool,
+    send_verification_email: bool = False,
 ) -> bool:
     print(f"\n  User #{user.id} — {user.name} {user.surname} <{user.email}>")
 
@@ -254,6 +270,15 @@ def migrate_user(
     if ok:
         print(f"    Password hash injected successfully (len={len(django_hash)}).")
 
+    if send_verification_email:
+        if dry_run:
+            print(f"    [dry-run] Would send verification email to {user.email}")
+        else:
+            link = api.send_verification_email(authentik_pk)
+            print(f"    Verification email sent to {user.email}.")
+            if link:
+                print(f"    Recovery link (backup): {link}")
+
     return ok
 
 
@@ -277,6 +302,8 @@ def main():
                         help="Migrate all platform users (use after validating with --ids first)")
     parser.add_argument("--dry-run", action="store_true",
                         help="Preview what would happen without making any changes")
+    parser.add_argument("--send-verification-email", action="store_true",
+                        help="Send a verification email to each migrated user via Authentik's recovery flow")
     parser.add_argument("--no-verify-ssl", action="store_true",
                         help="Disable SSL verification (for self-signed certs)")
     args = parser.parse_args()
@@ -343,7 +370,8 @@ def main():
     fail_count = 0
     for user in users:
         try:
-            success = migrate_user(user, api, authentik_conn, args.dry_run)
+            success = migrate_user(user, api, authentik_conn, args.dry_run,
+                                   send_verification_email=args.send_verification_email)
             if success:
                 ok_count += 1
             else:

--- a/scripts/migrate_users_to_authentik.py
+++ b/scripts/migrate_users_to_authentik.py
@@ -81,6 +81,20 @@ def fetch_users_by_ids(conn, ids: list[int]) -> list[PlatformUser]:
         return [_row_to_user(r) for r in cur.fetchall()]
 
 
+def fetch_all_users(conn) -> list[PlatformUser]:
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            """
+            SELECT u.id, u.name, u.surname, u.hashed_password, u.nmec, u.scopes,
+                   ue.email
+            FROM nei.user u
+            LEFT JOIN nei.user_email ue ON ue.user_id = u.id AND ue.active = true
+            ORDER BY u.id
+            """,
+        )
+        return [_row_to_user(r) for r in cur.fetchall()]
+
+
 def fetch_users_by_emails(conn, emails: list[str]) -> list[PlatformUser]:
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute(
@@ -259,14 +273,16 @@ def main():
                         help="Platform user IDs to migrate")
     parser.add_argument("--emails", nargs="+", metavar="EMAIL",
                         help="Platform user emails to migrate")
+    parser.add_argument("--all", action="store_true", dest="all_users",
+                        help="Migrate all platform users (use after validating with --ids first)")
     parser.add_argument("--dry-run", action="store_true",
                         help="Preview what would happen without making any changes")
     parser.add_argument("--no-verify-ssl", action="store_true",
                         help="Disable SSL verification (for self-signed certs)")
     args = parser.parse_args()
 
-    if not args.ids and not args.emails:
-        parser.error("Provide at least --ids or --emails")
+    if not args.ids and not args.emails and not args.all_users:
+        parser.error("Provide at least --ids, --emails, or --all")
 
     # Read env vars
     platform_db_url = os.environ.get("PLATFORM_DB_URL", "postgresql://postgres:postgres@localhost:5432/postgres")
@@ -300,10 +316,18 @@ def main():
 
     # Fetch users from platform DB
     users = []
-    if args.ids:
-        users += fetch_users_by_ids(platform_conn, args.ids)
-    if args.emails:
-        users += fetch_users_by_emails(platform_conn, args.emails)
+    if args.all_users:
+        if not args.dry_run:
+            confirm = input("Migrate ALL users? This cannot be undone. Type 'yes' to confirm: ")
+            if confirm.strip().lower() != "yes":
+                print("Aborted.")
+                sys.exit(0)
+        users = fetch_all_users(platform_conn)
+    else:
+        if args.ids:
+            users += fetch_users_by_ids(platform_conn, args.ids)
+        if args.emails:
+            users += fetch_users_by_emails(platform_conn, args.emails)
 
     if not users:
         print("No users found matching the given criteria.")

--- a/scripts/migrate_users_to_authentik.py
+++ b/scripts/migrate_users_to_authentik.py
@@ -70,11 +70,13 @@ def fetch_users_by_ids(conn, ids: list[int]) -> list[PlatformUser]:
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute(
             """
-            SELECT u.id, u.name, u.surname, u.hashed_password, u.nmec, u.scopes,
+            SELECT DISTINCT ON (u.id)
+                   u.id, u.name, u.surname, u.hashed_password, u.nmec, u.scopes,
                    ue.email
             FROM nei.user u
             LEFT JOIN nei.user_email ue ON ue.user_id = u.id AND ue.active = true
             WHERE u.id = ANY(%s)
+            ORDER BY u.id
             """,
             (ids,),
         )
@@ -85,7 +87,8 @@ def fetch_all_users(conn) -> list[PlatformUser]:
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute(
             """
-            SELECT u.id, u.name, u.surname, u.hashed_password, u.nmec, u.scopes,
+            SELECT DISTINCT ON (u.id)
+                   u.id, u.name, u.surname, u.hashed_password, u.nmec, u.scopes,
                    ue.email
             FROM nei.user u
             LEFT JOIN nei.user_email ue ON ue.user_id = u.id AND ue.active = true
@@ -99,11 +102,13 @@ def fetch_users_by_emails(conn, emails: list[str]) -> list[PlatformUser]:
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute(
             """
-            SELECT u.id, u.name, u.surname, u.hashed_password, u.nmec, u.scopes,
+            SELECT DISTINCT ON (u.id)
+                   u.id, u.name, u.surname, u.hashed_password, u.nmec, u.scopes,
                    ue.email
             FROM nei.user u
             JOIN nei.user_email ue ON ue.user_id = u.id AND ue.active = true
             WHERE ue.email = ANY(%s)
+            ORDER BY u.id
             """,
             (emails,),
         )
@@ -173,7 +178,13 @@ class AuthentikAPI:
         authentication flow can check this flag and prompt for email
         verification on the user's first login.
         """
-        username = user.email.split("@")[0] if user.email else f"user_{user.id}"
+        # nmec is unique per student; fall back to email-prefix + id to avoid collisions
+        if user.nmec:
+            username = str(user.nmec)
+        elif user.email:
+            username = f"{user.email.split('@')[0]}_{user.id}"
+        else:
+            username = f"user_{user.id}"
         payload = {
             "username": username,
             "name": f"{user.name} {user.surname}".strip(),

--- a/scripts/migrate_users_to_authentik.py
+++ b/scripts/migrate_users_to_authentik.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""
+Migrate platform users to Authentik, preserving their existing password hashes.
+
+This script reads users from the platform's PostgreSQL database, creates them
+in Authentik via the REST API, then injects their converted Argon2 password
+hash directly into Authentik's database — so users can log in without a reset.
+
+Password hash conversion:
+  passlib (platform):  $argon2id$v=19$m=...,t=...,p=...$salt$hash
+  Django (Authentik):  argon2$argon2id$v=19$m=...,t=...,p=...$salt$hash
+  (only difference: prepend "argon2" to the passlib PHC string)
+
+Usage:
+    # Migrate specific users by platform user ID
+    python migrate_users_to_authentik.py --ids 1 2 3
+
+    # Migrate specific users by email
+    python migrate_users_to_authentik.py --emails alice@example.com bob@example.com
+
+    # Dry run (no changes made)
+    python migrate_users_to_authentik.py --ids 1 2 3 --dry-run
+
+Required environment variables:
+    PLATFORM_DB_URL      postgresql://postgres:postgres@localhost:5432/postgres
+    AUTHENTIK_URL        https://nei.web.ua.pt/authentik
+    AUTHENTIK_TOKEN      <admin API token from Authentik UI>
+    AUTHENTIK_DB_URL     postgresql://authentik:pass@authentik-db:5432/authentik
+
+Dependencies (install with pip):
+    psycopg2-binary requests
+"""
+
+import argparse
+import os
+import sys
+import textwrap
+from dataclasses import dataclass
+from typing import Optional
+
+try:
+    import psycopg2
+    import psycopg2.extras
+    import requests
+except ImportError:
+    print("Missing dependencies. Run: pip install psycopg2-binary requests")
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Data
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PlatformUser:
+    id: int
+    name: str
+    surname: str
+    email: Optional[str]
+    hashed_password: Optional[str]  # passlib argon2 PHC string or None (OIDC user)
+    nmec: Optional[int]
+    scopes: list
+
+
+# ---------------------------------------------------------------------------
+# Platform DB helpers
+# ---------------------------------------------------------------------------
+
+def fetch_users_by_ids(conn, ids: list[int]) -> list[PlatformUser]:
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            """
+            SELECT u.id, u.name, u.surname, u.hashed_password, u.nmec, u.scopes,
+                   ue.email
+            FROM nei.user u
+            LEFT JOIN nei.user_email ue ON ue.user_id = u.id AND ue.active = true
+            WHERE u.id = ANY(%s)
+            """,
+            (ids,),
+        )
+        return [_row_to_user(r) for r in cur.fetchall()]
+
+
+def fetch_users_by_emails(conn, emails: list[str]) -> list[PlatformUser]:
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            """
+            SELECT u.id, u.name, u.surname, u.hashed_password, u.nmec, u.scopes,
+                   ue.email
+            FROM nei.user u
+            JOIN nei.user_email ue ON ue.user_id = u.id AND ue.active = true
+            WHERE ue.email = ANY(%s)
+            """,
+            (emails,),
+        )
+        return [_row_to_user(r) for r in cur.fetchall()]
+
+
+def _row_to_user(row: dict) -> PlatformUser:
+    return PlatformUser(
+        id=row["id"],
+        name=row["name"],
+        surname=row["surname"],
+        email=row["email"],
+        hashed_password=row["hashed_password"],
+        nmec=row["nmec"],
+        scopes=row["scopes"] or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Password hash conversion
+# ---------------------------------------------------------------------------
+
+def passlib_to_django_argon2(passlib_hash: str) -> str:
+    """
+    Convert a passlib argon2 PHC string to Django/Authentik format.
+
+    passlib: $argon2id$v=19$m=65536,t=2,p=2$<salt>$<hash>
+    Django:  argon2$argon2id$v=19$m=65536,t=2,p=2$<salt>$<hash>
+    """
+    if not passlib_hash.startswith("$argon2"):
+        raise ValueError(
+            f"Expected passlib argon2 hash starting with '$argon2', got: {passlib_hash[:20]}..."
+        )
+    return "argon2" + passlib_hash
+
+
+# ---------------------------------------------------------------------------
+# Authentik API helpers
+# ---------------------------------------------------------------------------
+
+class AuthentikAPI:
+    def __init__(self, base_url: str, token: str, verify_ssl: bool = True):
+        self.base = base_url.rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update({"Authorization": f"Bearer {token}"})
+        self.verify_ssl = verify_ssl
+
+    def _get(self, path: str, params: dict = None) -> dict:
+        r = self.session.get(f"{self.base}/api/v3{path}", params=params, verify=self.verify_ssl)
+        r.raise_for_status()
+        return r.json()
+
+    def _post(self, path: str, json: dict) -> dict:
+        r = self.session.post(f"{self.base}/api/v3{path}", json=json, verify=self.verify_ssl)
+        r.raise_for_status()
+        return r.json()
+
+    def find_user_by_email(self, email: str) -> Optional[dict]:
+        result = self._get("/core/users/", params={"email": email})
+        results = result.get("results", [])
+        return results[0] if results else None
+
+    def create_user(self, user: PlatformUser) -> dict:
+        """Create user in Authentik (without password — injected separately)."""
+        username = user.email.split("@")[0] if user.email else f"user_{user.id}"
+        payload = {
+            "username": username,
+            "name": f"{user.name} {user.surname}".strip(),
+            "email": user.email or "",
+            "is_active": True,
+            "type": "internal",
+            "attributes": {
+                "platform_id": user.id,
+                "nmec": user.nmec,
+                "platform_scopes": user.scopes,
+            },
+        }
+        return self._post("/core/users/", json=payload)
+
+
+# ---------------------------------------------------------------------------
+# Authentik DB helpers
+# ---------------------------------------------------------------------------
+
+def inject_password_hash(authentik_conn, authentik_user_pk: int, django_hash: str, dry_run: bool):
+    """Write the converted password hash into Authentik's user table."""
+    if len(django_hash) > 128:
+        print(f"    WARNING: hash length {len(django_hash)} > 128 chars (column max_length).")
+        print(f"             This may be truncated or rejected. Skipping hash injection.")
+        return False
+
+    if dry_run:
+        print(f"    [dry-run] Would write hash (len={len(django_hash)}) to authentik_core_user pk={authentik_user_pk}")
+        return True
+
+    with authentik_conn.cursor() as cur:
+        cur.execute(
+            "UPDATE authentik_core_user SET password = %s WHERE pk = %s",
+            (django_hash, authentik_user_pk),
+        )
+    authentik_conn.commit()
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Main migration logic
+# ---------------------------------------------------------------------------
+
+def migrate_user(
+    user: PlatformUser,
+    api: AuthentikAPI,
+    authentik_conn,
+    dry_run: bool,
+) -> bool:
+    print(f"\n  User #{user.id} — {user.name} {user.surname} <{user.email}>")
+
+    if not user.email:
+        print("    SKIP: no active email on record.")
+        return False
+
+    # Check if already exists in Authentik
+    existing = api.find_user_by_email(user.email)
+    if existing:
+        authentik_pk = existing["pk"]
+        print(f"    Found existing Authentik user pk={authentik_pk} — will update hash only.")
+    else:
+        if dry_run:
+            print(f"    [dry-run] Would create Authentik user for {user.email}")
+            authentik_pk = None
+        else:
+            created = api.create_user(user)
+            authentik_pk = created["pk"]
+            print(f"    Created Authentik user pk={authentik_pk}")
+
+    # Handle password
+    if not user.hashed_password:
+        print("    NOTE: no password hash (OIDC-only user). Skipping hash injection.")
+        print("          User will need to set a password in Authentik or use SSO.")
+        return True
+
+    django_hash = passlib_to_django_argon2(user.hashed_password)
+
+    if authentik_pk is None:
+        print(f"    [dry-run] Would inject hash (len={len(django_hash)})")
+        return True
+
+    ok = inject_password_hash(authentik_conn, authentik_pk, django_hash, dry_run)
+    if ok:
+        print(f"    Password hash injected successfully (len={len(django_hash)}).")
+
+    return ok
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Migrate platform users to Authentik with password hash preservation.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent("""
+            Environment variables:
+              PLATFORM_DB_URL      Platform PostgreSQL URL
+              AUTHENTIK_URL        Authentik base URL (e.g. https://nei.web.ua.pt/authentik)
+              AUTHENTIK_TOKEN      Authentik admin API token
+              AUTHENTIK_DB_URL     Authentik PostgreSQL URL
+        """),
+    )
+    parser.add_argument("--ids", nargs="+", type=int, metavar="ID",
+                        help="Platform user IDs to migrate")
+    parser.add_argument("--emails", nargs="+", metavar="EMAIL",
+                        help="Platform user emails to migrate")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Preview what would happen without making any changes")
+    parser.add_argument("--no-verify-ssl", action="store_true",
+                        help="Disable SSL verification (for self-signed certs)")
+    args = parser.parse_args()
+
+    if not args.ids and not args.emails:
+        parser.error("Provide at least --ids or --emails")
+
+    # Read env vars
+    platform_db_url = os.environ.get("PLATFORM_DB_URL", "postgresql://postgres:postgres@localhost:5432/postgres")
+    authentik_url   = os.environ.get("AUTHENTIK_URL")
+    authentik_token = os.environ.get("AUTHENTIK_TOKEN")
+    authentik_db_url = os.environ.get("AUTHENTIK_DB_URL")
+
+    missing = [k for k, v in {
+        "AUTHENTIK_URL": authentik_url,
+        "AUTHENTIK_TOKEN": authentik_token,
+        "AUTHENTIK_DB_URL": authentik_db_url,
+    }.items() if not v]
+    if missing:
+        print(f"Missing required environment variables: {', '.join(missing)}")
+        sys.exit(1)
+
+    if args.dry_run:
+        print("=== DRY RUN — no changes will be made ===\n")
+
+    # Connect to both databases
+    print("Connecting to platform database...")
+    platform_conn = psycopg2.connect(platform_db_url)
+
+    print("Connecting to Authentik database...")
+    if args.dry_run:
+        authentik_conn = None
+    else:
+        authentik_conn = psycopg2.connect(authentik_db_url)
+
+    api = AuthentikAPI(authentik_url, authentik_token, verify_ssl=not args.no_verify_ssl)
+
+    # Fetch users from platform DB
+    users = []
+    if args.ids:
+        users += fetch_users_by_ids(platform_conn, args.ids)
+    if args.emails:
+        users += fetch_users_by_emails(platform_conn, args.emails)
+
+    if not users:
+        print("No users found matching the given criteria.")
+        sys.exit(0)
+
+    print(f"\nFound {len(users)} user(s) to migrate:")
+    for u in users:
+        has_pw = "has password" if u.hashed_password else "no password (OIDC)"
+        print(f"  #{u.id} {u.name} {u.surname} <{u.email}> [{has_pw}]")
+
+    print("\n--- Starting migration ---")
+    ok_count = 0
+    fail_count = 0
+    for user in users:
+        try:
+            success = migrate_user(user, api, authentik_conn, args.dry_run)
+            if success:
+                ok_count += 1
+            else:
+                fail_count += 1
+        except Exception as e:
+            print(f"    ERROR: {e}")
+            fail_count += 1
+
+    platform_conn.close()
+    if authentik_conn:
+        authentik_conn.close()
+
+    print(f"\n--- Done: {ok_count} succeeded, {fail_count} failed ---")
+    if args.dry_run:
+        print("(dry run — no actual changes were made)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate_users_to_authentik.py
+++ b/scripts/migrate_users_to_authentik.py
@@ -186,6 +186,31 @@ class AuthentikAPI:
         results = result.get("results", [])
         return results[0] if results else None
 
+    def patch_user(self, pk: int, user: PlatformUser) -> None:
+        """Update name, email and platform attributes on an existing Authentik user.
+
+        Does NOT touch needs_email_verification — we preserve whatever state it
+        is in so we don't re-trigger email verification for users who already
+        completed it.
+        """
+        existing = self._get(f"/core/users/{pk}/")
+        existing_attrs = existing.get("attributes") or {}
+        r = self.session.patch(
+            f"{self.base}/api/v3/core/users/{pk}/",
+            json={
+                "name": f"{user.name} {user.surname}".strip(),
+                "email": user.email or "",
+                "attributes": {
+                    **existing_attrs,
+                    "platform_id": user.id,
+                    "nmec": user.nmec,
+                    "platform_scopes": user.scopes,
+                },
+            },
+            verify=self.verify_ssl,
+        )
+        r.raise_for_status()
+
     def create_user(self, user: PlatformUser) -> dict:
         """Create user in Authentik (without password — injected separately).
 
@@ -234,12 +259,11 @@ class AuthentikAPI:
 # ---------------------------------------------------------------------------
 
 def inject_password_hash(authentik_conn, authentik_user_pk: int, django_hash: str, dry_run: bool):
-    """Write the converted password hash into Authentik's user table."""
-    if len(django_hash) > 128:
-        print(f"    WARNING: hash length {len(django_hash)} > 128 chars (column max_length).")
-        print(f"             This may be truncated or rejected. Skipping hash injection.")
-        return False
+    """Write the converted password hash into Authentik's user table.
 
+    Typical argon2id hashes are ~100 chars. Authentik's password column
+    accepts up to 300 chars, so this should never fail for realistic params.
+    """
     if dry_run:
         print(f"    [dry-run] Would write hash (len={len(django_hash)}) to authentik_core_user pk={authentik_user_pk}")
         return True
@@ -273,7 +297,11 @@ def migrate_user(
     existing = api.find_user_by_email(user.email)
     if existing:
         authentik_pk = existing["pk"]
-        print(f"    Found existing Authentik user pk={authentik_pk} — will update hash only.")
+        print(f"    Found existing Authentik user pk={authentik_pk} — updating attributes and hash.")
+        if dry_run:
+            print(f"    [dry-run] Would PATCH name/email/platform attributes for pk={authentik_pk}")
+        else:
+            api.patch_user(authentik_pk, user)
     else:
         if dry_run:
             print(f"    [dry-run] Would create Authentik user for {user.email}")
@@ -297,8 +325,7 @@ def migrate_user(
 
     ok = inject_password_hash(authentik_conn, authentik_pk, django_hash, dry_run)
     if ok:
-        print(f"    Password hash injected successfully (len={len(django_hash)}).")
-        print(f"    Email verification will be prompted on first login (needs_email_verification=True).")
+        print(f"    Password hash injected (len={len(django_hash)}).")
 
     return ok
 

--- a/scripts/migrate_users_to_authentik.py
+++ b/scripts/migrate_users_to_authentik.py
@@ -33,8 +33,10 @@ Dependencies (install with pip):
 
 import argparse
 import os
+import re
 import sys
 import textwrap
+import unicodedata
 from dataclasses import dataclass
 from typing import Optional
 
@@ -115,6 +117,19 @@ def fetch_users_by_emails(conn, emails: list[str]) -> list[PlatformUser]:
         return [_row_to_user(r) for r in cur.fetchall()]
 
 
+def _slugify(text: str) -> str:
+    """Lowercase, strip accents, replace non-alphanumeric runs with underscores."""
+    text = unicodedata.normalize("NFKD", text)
+    text = text.encode("ascii", "ignore").decode("ascii")
+    text = text.lower()
+    return re.sub(r"[^a-z0-9]+", "_", text).strip("_")
+
+
+def _make_username(user: PlatformUser, suffix: str = "") -> str:
+    base = _slugify(f"{user.name}_{user.surname}") or f"user_{user.id}"
+    return f"{base}{suffix}"
+
+
 def _row_to_user(row: dict) -> PlatformUser:
     return PlatformUser(
         id=row["id"],
@@ -177,16 +192,11 @@ class AuthentikAPI:
         Sets needs_email_verification=True in attributes so the Authentik
         authentication flow can check this flag and prompt for email
         verification on the user's first login.
+
+        Username is derived from name_surname (slugified). If that collides,
+        falls back to name_surname_<platform_id>, which is always unique.
         """
-        # nmec is unique per student; fall back to email-prefix + id to avoid collisions
-        if user.nmec:
-            username = str(user.nmec)
-        elif user.email:
-            username = f"{user.email.split('@')[0]}_{user.id}"
-        else:
-            username = f"user_{user.id}"
-        payload = {
-            "username": username,
+        base_payload = {
             "name": f"{user.name} {user.surname}".strip(),
             "email": user.email or "",
             "is_active": True,
@@ -202,7 +212,21 @@ class AuthentikAPI:
                 "needs_email_verification": True,
             },
         }
-        return self._post("/core/users/", json=payload)
+
+        for suffix in ("", f"_{user.id}"):
+            username = _make_username(user, suffix)
+            r = self.session.post(
+                f"{self.base}/api/v3/core/users/",
+                json={**base_payload, "username": username},
+                verify=self.verify_ssl,
+            )
+            if r.status_code == 400 and "username" in r.text and not suffix:
+                print(f"    Username '{username}' taken — retrying with '_{user.id}' suffix.")
+                continue
+            r.raise_for_status()
+            return r.json()
+
+        raise RuntimeError(f"Could not create Authentik user for platform #{user.id}")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/migrate_users_to_authentik.py
+++ b/scripts/migrate_users_to_authentik.py
@@ -167,7 +167,12 @@ class AuthentikAPI:
         return results[0] if results else None
 
     def create_user(self, user: PlatformUser) -> dict:
-        """Create user in Authentik (without password — injected separately)."""
+        """Create user in Authentik (without password — injected separately).
+
+        Sets needs_email_verification=True in attributes so the Authentik
+        authentication flow can check this flag and prompt for email
+        verification on the user's first login.
+        """
         username = user.email.split("@")[0] if user.email else f"user_{user.id}"
         payload = {
             "username": username,
@@ -179,24 +184,14 @@ class AuthentikAPI:
                 "platform_id": user.id,
                 "nmec": user.nmec,
                 "platform_scopes": user.scopes,
+                # Checked by the Authentik authentication flow policy:
+                # if True, the Email Verification stage is shown on first login.
+                # Authentik clears this (or sets email_verified=True) after
+                # the user completes verification.
+                "needs_email_verification": True,
             },
         }
         return self._post("/core/users/", json=payload)
-
-    def send_verification_email(self, authentik_pk: int) -> str:
-        """
-        Trigger Authentik's recovery flow for the user, which sends them an
-        email with a link to verify their address.
-
-        The link goes through whichever recovery flow is configured in Authentik.
-        To make this purely an email verification (no forced password change),
-        configure the recovery flow in Authentik to include an Email Verification
-        stage but no Password Change stage — or make the password stage optional.
-
-        Returns the recovery link URL (also sent by email if an email stage is set up).
-        """
-        result = self._post(f"/core/users/{authentik_pk}/recovery/", json={})
-        return result.get("link", "")
 
 
 # ---------------------------------------------------------------------------
@@ -232,7 +227,6 @@ def migrate_user(
     api: AuthentikAPI,
     authentik_conn,
     dry_run: bool,
-    send_verification_email: bool = False,
 ) -> bool:
     print(f"\n  User #{user.id} — {user.name} {user.surname} <{user.email}>")
 
@@ -269,15 +263,7 @@ def migrate_user(
     ok = inject_password_hash(authentik_conn, authentik_pk, django_hash, dry_run)
     if ok:
         print(f"    Password hash injected successfully (len={len(django_hash)}).")
-
-    if send_verification_email:
-        if dry_run:
-            print(f"    [dry-run] Would send verification email to {user.email}")
-        else:
-            link = api.send_verification_email(authentik_pk)
-            print(f"    Verification email sent to {user.email}.")
-            if link:
-                print(f"    Recovery link (backup): {link}")
+        print(f"    Email verification will be prompted on first login (needs_email_verification=True).")
 
     return ok
 
@@ -302,8 +288,6 @@ def main():
                         help="Migrate all platform users (use after validating with --ids first)")
     parser.add_argument("--dry-run", action="store_true",
                         help="Preview what would happen without making any changes")
-    parser.add_argument("--send-verification-email", action="store_true",
-                        help="Send a verification email to each migrated user via Authentik's recovery flow")
     parser.add_argument("--no-verify-ssl", action="store_true",
                         help="Disable SSL verification (for self-signed certs)")
     args = parser.parse_args()
@@ -370,8 +354,7 @@ def main():
     fail_count = 0
     for user in users:
         try:
-            success = migrate_user(user, api, authentik_conn, args.dry_run,
-                                   send_verification_email=args.send_verification_email)
+            success = migrate_user(user, api, authentik_conn, args.dry_run)
             if success:
                 ok_count += 1
             else:


### PR DESCRIPTION
## Summary

Significantly refactors the OIDC/OpenID Connect authentication module to improve security, maintainability, and user experience. Introduces cryptographically signed state cookies for CSRF protection, simplifies the OAuth flow, and adds comprehensive documentation. Also includes a new migration script for moving existing users to Authentik while preserving password hashes.

## Key Changes

### OIDC Module (`api/api_v1/auth/oidc.py`)

**Security & CSRF Protection:**
- Replaced ad-hoc state handling with signed, HttpOnly state cookies using `itsdangerous.URLSafeTimedSerializer`
- State nonce is generated on each login/link request and verified on callback
- Cookies are short-lived (10 minutes) and automatically cleared after verification
- Prevents replay attacks and CSRF vulnerabilities

**Code Organization:**
- Restructured into logical sections with clear separation of concerns (OAuth setup, state helpers, token exchange, user upsert, routes)
- Extracted helper functions: `_load_endpoints()`, `_exchange_code()`, `_parse_scopes()`, `_require_oidc()`
- Improved error handling with consistent HTTP status codes and messages

**User Management:**
- Enhanced `get_or_create_user_from_oidc()` to sync user data on every login (name, surname, nmec, iupi, scopes)
- Implements two-step lookup: first by `authentik_sub` (fast path), then by email (auto-link migrated users)
- Properly handles scope normalization and validation against `ScopeEnum`

**Account Linking Flow:**
- `/oidc/link` now uses state cookies to securely pass `user_id` to the callback
- `/oidc/link-callback` verifies state and prevents linking to already-linked accounts
- Clearer error messages and proper HTTP status codes (409 for conflicts)

**Documentation:**
- Added comprehensive module docstring with flow diagrams for login and account linking
- Documented state/CSRF protection mechanism
- Listed Authentik property-mapping requirements with exact expressions needed

**Callback Improvements:**
- `redirect_to` parameter is now passed via state cookie instead of query string
- Returned in response headers (`X-Redirect-To`) so frontend can navigate after token storage
- Cleaner separation between OAuth state and application state

### Migration Script (`scripts/migrate_users_to_authentik.py`)

New utility script for migrating existing platform users to Authentik:
- Reads users from platform PostgreSQL database
- Creates them in Authentik via REST API
- Converts passlib argon2 hashes to Django/Authentik format and injects directly into Authentik DB
- Preserves user attributes (nmec, platform_scopes) as Authentik custom attributes
- Supports selective migration by user IDs or emails, with dry-run mode
- Handles username collisions by appending user ID suffix
- Sets `needs_email_verification` flag for email verification on first login

## Notable Implementation Details

- Reuses JWT private key as HMAC secret for state cookie signing (already confidential, consistent across replicas)
- SSL verification respects `PRODUCTION` setting for self-signed certs in development
- Password hash conversion is transparent: `$argon2id$...` → `argon2$argon2id$...`
- Migration script includes comprehensive error handling and user feedback
- State payload is flexible (supports `redirect_to` and `user_id` as needed)

https://claude.ai/code/session_01DyzugEsHXp3vzniAjY4Xw2