### PR TITLE
feat: add manager gala role and enable gala extension routes

### DIFF
--- a/api-nei/app/schemas/user/user.py
+++ b/api-nei/app/schemas/user/user.py
@@ -34,6 +34,7 @@ class ScopeEnum(str, Enum):
     MANAGER_TACAUA = "manager-tacaua"
     MANAGER_FAMILY = "manager-family"
     MANAGER_ARRAIAL = "manager-arraial"
+    MANAGER_GALA = "manager-gala"
     MANAGER_GAMIFICATION = "manager-gamification"
     DEFAULT = "default"
 

--- a/dev/proxy/locations.gala.conf
+++ b/dev/proxy/locations.gala.conf
@@ -1,10 +1,17 @@
-# gala Extension Routes (disabled)
-# Proxy to main platform for consistent 404 handling
+# gala Extension Routes (enabled)
 
 location ~ ^/(api|static)/gala(/.*)?$ {
-    return 404;
+    limit_except GET POST PUT DELETE {
+        deny all;
+    }
+
+    proxy_pass http://api_gala:8004;
 }
 
 location ~ ^/gala(/.*)?$ {
-    proxy_pass http://web_nei:3000;
+    proxy_pass http://web_gala:3002;
+}
+
+location = /gala {
+    return 301 /gala/;
 }


### PR DESCRIPTION
This pull request introduces support for the new "gala" extension across both backend and proxy configurations. The key changes include updating user scope enumerations and enabling proxy routes specifically for the "gala" extension.

Backend update:

* Added `MANAGER_GALA` to the `ScopeEnum` in `user.py`, allowing for user roles specific to the "gala" extension.

Proxy configuration changes:

* Enabled and configured proxy routes for `/gala` and `/api/static/gala` endpoints in `locations.gala.conf`, routing requests to the appropriate backend and frontend services, and enforcing HTTP method restrictions.