### PR TITLE
fix(ci): drop submodule checkout from build.yml (fixes missing-token failure)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,19 +48,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-          submodules: recursive
-          token: ${{ secrets.GH_PAT }}
+          # Shallow clones should be disabled for a better relevancy of analysis.
+          fetch-depth: 0
+          # No submodules: this job only builds, tests, and analyzes the core
+          # platform (api-nei, api-family, web-nei; see sonar.sources). Checking
+          # out extensions/* here required secrets.GH_PAT, which pull_request
+          # runs (Dependabot and forks) don't receive — that was the
+          # "Input required and not supplied: token" checkout failure. Dropping
+          # it lets the default GITHUB_TOKEN handle the checkout.
 
-      - name: Update extension submodules to tracked branches
-        run: |
-          # Initialize and update Rally submodule (required)
-          git submodule update --init extensions/rally || true
-          git submodule update --remote --merge extensions/rally || true
-          # Initialize and update Gala submodule (optional - may fail if repo is private or not accessible)
-          git submodule update --init extensions/gala || echo "Warning: Gala submodule not accessible, skipping"
-          git submodule update --remote --merge extensions/gala || echo "Warning: Gala submodule update failed, skipping"
-      
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
## Problem

`build.yml` (the Sonar/test job) fails at the very first step on pull requests:

```
Input required and not supplied: token
```

`actions/checkout@v4` is configured with `token: ${{ secrets.GH_PAT }}`, but **`pull_request` runs from Dependabot and forks don't receive that secret**, so it resolves to an empty string and checkout aborts before any build/test/analysis runs. Seen on `dependabot/pip/api-family/pip-4c787c4c77`, but it affects every such PR.

## Fix

This job **never uses the submodules** — it builds, tests, and analyzes only the core platform (`api-nei`, `api-family`, `web-nei`; see `sonar.sources`). So drop the submodule checkout entirely:

- Remove `submodules: recursive` + `token: ${{ secrets.GH_PAT }}` from the checkout (default `GITHUB_TOKEN` is enough).
- Remove the "Update extension submodules" step.

This also removes the now-dead `extensions/rally` init (rally is no longer a submodule after #206).

`deploy.yaml`, which legitimately needs submodules for releases, is **unchanged**.

## Notes
- For `pull_request`, the workflow runs from the PR's branch, so the Dependabot PR will pick this up after a rebase onto the updated `main` (`@dependabot rebase`).
- Separately, the Sonar step also needs "Automatic Analysis" disabled in the SonarQube Cloud dashboard (CI-based analysis + Automatic can't both be on) — that's a dashboard toggle, not a code change.