### PR TITLE
chore(ci): drop rally-only TEAM_JWT_SECRET_KEY from deploy.yaml

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -127,7 +127,6 @@ jobs:
       RECAPTCHA_SECRET_KEY: ${{ secrets.RECAPTCHA_SECRET_KEY }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-      TEAM_JWT_SECRET_KEY: ${{ secrets.TEAM_JWT_SECRET_KEY }}
       OIDC_CLIENT_SECRET: ${{ secrets.OIDC_CLIENT_SECRET }}
       AUTHENTIK_TOKEN: ${{ secrets.AUTHENTIK_TOKEN }}
       # Variables (public / non-sensitive config)


### PR DESCRIPTION
`TEAM_JWT_SECRET_KEY` (rally's team-QR auth) was only ever passed through to the rally extension's compose — never used by platform core (api-nei/api-family/compose.prod.yml). Rally is now standalone, so this is a dangling ref left over from #206.

After merge you can delete the **`TEAM_JWT_SECRET_KEY`** repository secret from the Platform repo.