### PR TITLE
fix(auth): correctness and hardening fixes in the session/refresh flow

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -1,0 +1,122 @@
+# NEI Platform Authentication Guide
+
+This guide explains how authentication works across the platform: what Authentik is responsible for, what the platform is responsible for, and which knobs actually change behaviour.
+
+## Overview
+
+**Authentik is the authentication authority. The platform is the session authority.**
+
+Authentik proves *who a user is* — once, at login — and supplies *what they are allowed to do* via claims. The platform then mints its own session and Authentik steps out of the loop until the next login.
+
+Concretely, the OIDC callback exchanges the authorization code, calls `/userinfo` once, validates the ID token, and then **discards every Authentik token**. No Authentik `access_token` or `refresh_token` is stored or reused. Everything after login runs on platform-issued ES512 JWTs backed by the `device_login` table.
+
+This is a deliberate design, not an oversight. `api-family`, `api-tacaua`, and the gala extension all verify the platform JWT with a shared public key, which keeps them trivially simple and free of any runtime dependency on Authentik. An Authentik outage blocks new logins; it does not log anyone out or break the API.
+
+## The two token types
+
+| | Platform access token | Platform refresh token |
+|---|---|---|
+| Format | ES512 JWT, signed with the platform key | ES512 JWT, same key |
+| Lifetime | `ACCESS_TOKEN_EXPIRE` — **1 hour** | `REFRESH_TOKEN_EXPIRE` — **24 hours** |
+| Storage | In memory (zustand store) — never `localStorage` | HttpOnly cookie, `SameSite=Strict`, path-scoped to `/api/nei/v1/auth` |
+| Carries | `sub`, `nmec`, `email`, `image`, `name`, `surname`, `scopes` | `sub`, `sid`, `jti` |
+| Revocable | No — valid until it expires | Yes — delete the `device_login` row |
+
+Both lifetimes are defined in [`api-nei/app/core/config.py`](api-nei/app/core/config.py). **Neither comes from Authentik.**
+
+The session is **absolute, not sliding**: `expires_at` is set once when the session is created and is never extended by a refresh. A user is sent back through Authentik 24 hours after login regardless of activity.
+
+## Login flow
+
+1. Frontend navigates to `GET /api/nei/v1/auth/oidc/login` (a full-page redirect — the SPA never talks to Authentik directly).
+2. Backend builds the authorization URL from Authentik's discovery document and redirects, with PKCE (S256), `state`, and `nonce`. State and PKCE verifier live in a signed, HttpOnly, 10-minute cookie.
+3. User authenticates with Authentik; Authentik redirects back to `/auth/oidc/callback`.
+4. Backend verifies `state`, exchanges the code, calls `/userinfo`, and fully validates the ID token — signature against JWKS, plus `iss`, `aud`, `exp`, `nonce`, and a `sub` cross-check against the userinfo response.
+5. `get_or_create_user_from_oidc` upserts the user and **re-reads scopes from Authentik claims on every login**.
+6. Backend mints the platform token pair and redirects to `/auth/oidc/return#token=...`, with the refresh cookie attached.
+7. Frontend reads the token from the URL **fragment** (never the query string — fragments are not sent to servers, logged, or leaked via `Referer`), stores it in memory, and clears it from history.
+
+## Session renewal
+
+The frontend never checks expiry proactively. It is entirely reactive:
+
+- On app mount, and on any `401`, it POSTs to `/api/nei/v1/auth/refresh` with the cookie.
+- The backend validates the refresh token, rotates it, and returns a fresh 1-hour access token.
+- The original request is replayed transparently. Concurrent 401s are de-duplicated so only one refresh fires.
+
+**Authentik is not involved in this.** Users do not re-authenticate when their access token expires — only when the 24-hour session ends, or when the session is revoked.
+
+### Rotation and replay detection
+
+Every refresh mints a new refresh token carrying a fresh 256-bit `jti`, which is stored on the `device_login` row. A token whose `jti` does not match the stored value is a replay: the request is rejected **and the entire session is deleted**. The row is read with `FOR UPDATE`, so two concurrent refreshes cannot both succeed and fork the session.
+
+Sessions created before the `jti` migration have a `NULL` value and fall back to an older timestamp comparison for exactly one rotation, then self-heal. Once all such rows have aged out (≤ 24h), `refresh_jti` should be made `NOT NULL` and the fallback branch in `_validate_refresh_token` deleted.
+
+## Which Authentik settings actually matter
+
+This is the part that most often causes confusion. Under the OAuth2/OIDC provider config:
+
+| Setting | Effect on the platform |
+|---|---|
+| **Access Code Validity** | ✅ **Real.** The window to exchange the code — one redirect plus one server-to-server call. Keep it at ~1 minute; that is already ~60× what is needed. |
+| **Access Token Validity** | ⚠️ **Effectively none.** The token is consumed by a single `/userinfo` call microseconds after issuance and then discarded. Raising it gains nothing. |
+| **Refresh Token Validity** | ❌ **None.** No refresh token is issued (`offline_access` is not requested) and no code path would read one. |
+| **Refresh Token Threshold** | ❌ **None.** Same reason. |
+
+**To change how long a session lasts, edit `ACCESS_TOKEN_EXPIRE` / `REFRESH_TOKEN_EXPIRE` — not Authentik.** Both are pydantic `timedelta` settings and can be overridden by environment variable using **ISO-8601 duration** format:
+
+```bash
+ACCESS_TOKEN_EXPIRE=PT30M     # 30 minutes
+REFRESH_TOKEN_EXPIRE=PT12H    # 12 hours
+```
+
+Plain seconds (`1800`) will **not** parse and will crash the container at startup.
+
+### The Authentik setting that does matter
+
+Whether the 24-hour re-login is a silent redirect or a real credential prompt depends on **Authentik's own SSO session duration**, configured in the brand/flow settings — *not* in the OAuth provider. If the session cap ever feels disruptive to users, that is the dial to look at.
+
+## Do not enable `offline_access`
+
+There is no code path that could consume an Authentik refresh token. Enabling the scope would make Authentik mint and persist long-lived refresh tokens on every login that the platform immediately throws away — attack surface with no benefit.
+
+It would only make sense as part of a deliberate migration to a different architecture (see below).
+
+## Configuration reference
+
+| Variable | Purpose | Notes |
+|---|---|---|
+| `OIDC_ENABLED` | Feature flag | Endpoints return 503 when false |
+| `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` | Provider credentials | |
+| `OIDC_DISCOVERY_URL` | Discovery document | Defaults to the production Authentik |
+| `OIDC_REDIRECT_BASE_URL` | Callback base | Defaults to `HOST` |
+| `OIDC_SCOPES` | Requested scopes | `openid profile email nei_scopes nei_nmec nei_iupi` — **no `offline_access`** |
+| `OIDC_VERIFY_SSL` | TLS verification for all Authentik calls | Defaults to `true`. Set `false` **only** for a local self-signed Authentik |
+| `AUTHENTIK_URL` / `AUTHENTIK_TOKEN` | Admin API credentials | Required for admin role management and display-name sync; those endpoints return 503 without the token |
+| `JWT_SECRET_KEY_PATH` / `JWT_PUBLIC_KEY_PATH` | Platform signing keys | The public key is what downstream services verify against |
+
+## Scopes
+
+Scopes are resolved from Authentik claims on **every** login, so Authentik remains the authorization source of truth:
+
+1. The `scopes` claim is checked first (set via the `nei_scopes` property mapping).
+2. Falls back to `groups`, stripping an optional `nei-` prefix.
+3. Unrecognised values are logged and skipped; an empty result becomes `["default"]`.
+
+Changes made directly in the platform database propagate on the next refresh (≤ 1 hour), because `/auth/refresh` re-reads the user. Changes made **in Authentik** only apply at the next login.
+
+## Known gaps
+
+- **Deprovisioning latency is up to 24 hours.** Disabling a user in Authentik does not end their existing platform session. This is the inherent cost of not using the IdP's tokens. The intended fix is a background reconciliation job sweeping `device_login` against Authentik's admin API — Ofelia already runs a nightly `cleanup-logins.sql` against this table, so it is a sibling job, not new infrastructure. It must **not** live in the `/auth/refresh` path, which would couple every session renewal to Authentik's availability.
+- **Access tokens cannot be revoked** before their 1-hour expiry. Validation is signature-only; there is no denylist.
+- **Password login still exists** (`/auth/login`) and issues identical sessions, bypassing Authentik's MFA and policies. It is not usable by OIDC-created accounts — they have a `NULL` password hash — but it remains available to any legacy account that still has one. Retiring it completes the migration.
+
+## When to reconsider this architecture
+
+The current model is the right trade for a set of first-party services. Revisit it if any of these become true:
+
+- Third-party or non-first-party API clients need access.
+- A mobile app is added.
+- Sub-minute revocation becomes a hard requirement.
+
+In that case the alternative is to make Authentik's access token the API credential — services become resource servers validating via JWKS, and refresh tokens are held server-side (where `offline_access` would finally be meaningful). The cost is a hard runtime dependency on Authentik in every service, re-modelling scopes as Authentik property mappings, and rewriting the session layer. Do not do it piecemeal.

--- a/api-nei/alembic/versions/a1b2c3d4e5f6_device_login_timestamps_tz_aware.py
+++ b/api-nei/alembic/versions/a1b2c3d4e5f6_device_login_timestamps_tz_aware.py
@@ -1,0 +1,50 @@
+"""Make device_login timestamps timezone-aware
+
+Revision ID: a1b2c3d4e5f6
+Revises: 3f1a2b4c5d6e
+Create Date: 2026-08-18 00:00:00.000000
+
+The USING clause is required for correctness, not syntax: without it
+Postgres interprets the existing naive values in the session TimeZone at
+ALTER time, which is the exact ambiguity being removed. Existing rows are
+UTC wall times because db_pg runs with TimeZone=UTC — verify with
+`SHOW TimeZone;` before applying to another deployment.
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "a1b2c3d4e5f6"
+down_revision = "3f1a2b4c5d6e"
+branch_labels = None
+depends_on = None
+
+_COLUMNS = ("refreshed_at", "expires_at")
+
+
+def upgrade() -> None:
+    for column in _COLUMNS:
+        op.alter_column(
+            "device_login",
+            column,
+            existing_type=sa.DateTime(),
+            type_=sa.DateTime(timezone=True),
+            existing_nullable=False,
+            postgresql_using=f"{column} AT TIME ZONE 'UTC'",
+            schema="nei",
+        )
+
+
+def downgrade() -> None:
+    for column in _COLUMNS:
+        op.alter_column(
+            "device_login",
+            column,
+            existing_type=sa.DateTime(timezone=True),
+            type_=sa.DateTime(),
+            existing_nullable=False,
+            postgresql_using=f"{column} AT TIME ZONE 'UTC'",
+            schema="nei",
+        )

--- a/api-nei/alembic/versions/b2c3d4e5f6a7_add_refresh_jti_to_device_login.py
+++ b/api-nei/alembic/versions/b2c3d4e5f6a7_add_refresh_jti_to_device_login.py
@@ -1,0 +1,35 @@
+"""Add refresh_jti to device_login for refresh-token replay detection
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-08-18 00:00:00.000000
+
+Nullable with no server default, so this is metadata-only on PG 11+ and
+does not rewrite the table. Sessions created before this migration have a
+NULL jti and fall back to the old timestamp check for exactly one
+rotation; see _validate_refresh_token. Every such row is gone within
+REFRESH_TOKEN_EXPIRE, after which a follow-up migration should make the
+column NOT NULL and the fallback branch should be deleted.
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "b2c3d4e5f6a7"
+down_revision = "a1b2c3d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "device_login",
+        sa.Column("refresh_jti", sa.String(length=64), nullable=True),
+        schema="nei",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("device_login", "refresh_jti", schema="nei")

--- a/api-nei/app/api/api_v1/admin.py
+++ b/api-nei/app/api/api_v1/admin.py
@@ -56,7 +56,7 @@ def _authentik_headers() -> dict:
 async def _authentik_user_pk(authentik_sub: str) -> int:
     """Resolve an Authentik user PK (int) from their UUID (authentik_sub)."""
     url = f"{settings.AUTHENTIK_URL}/api/v3/core/users/"
-    verify_ssl = settings.PRODUCTION
+    verify_ssl = settings.OIDC_VERIFY_SSL
     async with httpx.AsyncClient(verify=verify_ssl) as client:
         resp = await client.get(
             url,
@@ -85,7 +85,7 @@ async def list_authentik_groups(
         )
 
     url = f"{settings.AUTHENTIK_URL}/api/v3/core/groups/"
-    verify_ssl = settings.PRODUCTION
+    verify_ssl = settings.OIDC_VERIFY_SSL
     groups = []
     params = {"include_users": "true", "page_size": 100}
 
@@ -128,7 +128,7 @@ async def add_group_member(
     safe_group_pk = _validate_uuid(group_pk, "group_pk")
     authentik_pk = await _authentik_user_pk(user.authentik_sub)
     url = f"{settings.AUTHENTIK_URL}/api/v3/core/groups/{safe_group_pk}/add_user/"
-    verify_ssl = settings.PRODUCTION
+    verify_ssl = settings.OIDC_VERIFY_SSL
     async with httpx.AsyncClient(verify=verify_ssl) as client:
         resp = await client.post(
             url,
@@ -162,7 +162,7 @@ async def remove_group_member(
     safe_group_pk = _validate_uuid(group_pk, "group_pk")
     authentik_pk = await _authentik_user_pk(user.authentik_sub)
     url = f"{settings.AUTHENTIK_URL}/api/v3/core/groups/{safe_group_pk}/remove_user/"
-    verify_ssl = settings.PRODUCTION
+    verify_ssl = settings.OIDC_VERIFY_SSL
     async with httpx.AsyncClient(verify=verify_ssl) as client:
         resp = await client.post(
             url,

--- a/api-nei/app/api/api_v1/auth/_deps.py
+++ b/api-nei/app/api/api_v1/auth/_deps.py
@@ -20,6 +20,10 @@ from app.core.dynamic_oauth import dynamic_oauth2_scheme
 
 ACCESS_TOKEN_TYPE: str = "access"
 REFRESH_TOKEN_TYPE: str = "refresh"
+# Cookie identity is (name, domain, path); set and delete must agree or the
+# browser silently keeps the cookie.
+REFRESH_COOKIE_NAME: str = "refresh"
+REFRESH_COOKIE_PATH: str = f"{settings.API_V1_STR}/auth"
 VERIFICATION_TOKEN_TYPE: str = "verification"
 PASSWORD_RESET_TOKEN_TYPE: str = "reset"
 MAGIC_LINK_TOKEN_TYPE: str = "magic"
@@ -255,16 +259,27 @@ def generate_response(
 
     response = JSONResponse(content=token_data.model_dump())
     response.set_cookie(
-        key="refresh",
+        key=REFRESH_COOKIE_NAME,
         value=refresh_token,
         expires=device_login.expires_at.astimezone(tz=timezone.utc),
         secure=settings.PRODUCTION,
         httponly=True,
         samesite="strict",
         # Only pass the cookie to the auth endpoints
-        path=f"{settings.API_V1_STR}/auth",
+        path=REFRESH_COOKIE_PATH,
     )
     return response
+
+
+def clear_refresh_cookie(response: Response) -> None:
+    """Expires the refresh cookie client-side, mirroring `generate_response`."""
+    response.delete_cookie(
+        REFRESH_COOKIE_NAME,
+        path=REFRESH_COOKIE_PATH,
+        secure=settings.PRODUCTION,
+        httponly=True,
+        samesite="strict",
+    )
 
 
 class OperationSuccessfulResponse(BaseModel):

--- a/api-nei/app/api/api_v1/auth/_deps.py
+++ b/api-nei/app/api/api_v1/auth/_deps.py
@@ -1,3 +1,5 @@
+import secrets
+
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer, SecurityScopes
 from fastapi.responses import JSONResponse, Response
@@ -211,6 +213,9 @@ def generate_response(
     # created device login and refreshed token otherwise the token could be
     # denied because the dates mismatch.
     iat = datetime.now(timezone.utc)
+    # Rotation identity. Kept in a local because db.commit() below expires the
+    # instance, and the value must match what goes into the token.
+    refresh_jti = secrets.token_urlsafe(32)
 
     if device_login is None:
         # Create a new session and add it to the database if no session exists
@@ -220,11 +225,13 @@ def generate_response(
             refreshed_at=iat,
             expires_at=iat + settings.REFRESH_TOKEN_EXPIRE,
             oidc_id_token=oidc_id_token,
+            refresh_jti=refresh_jti,
         )
         db.add(device_login)
     else:
         # Update the last time the token was refreshed if the session already exists
         device_login.refreshed_at = iat
+        device_login.refresh_jti = refresh_jti
 
     # Flush all changes to the database to ensure consistency
     db.commit()
@@ -252,6 +259,7 @@ def generate_response(
             "sub": str(user.id),
             "type": REFRESH_TOKEN_TYPE,
             "sid": device_login.session_id,
+            "jti": refresh_jti,
         },
     )
 

--- a/api-nei/app/api/api_v1/auth/oidc.py
+++ b/api-nei/app/api/api_v1/auth/oidc.py
@@ -71,7 +71,7 @@ if settings.OIDC_ENABLED:
         "token_endpoint_auth_method": "client_secret_post",
         "code_challenge_method": "S256",
     }
-    if not settings.PRODUCTION:
+    if not settings.OIDC_VERIFY_SSL:
         client_kwargs["verify"] = False
 
     oauth.register(
@@ -191,7 +191,7 @@ async def _load_endpoints() -> tuple[str, str]:
 
 
 async def _fetch_jwks(jwks_uri: str) -> dict:
-    verify_ssl = settings.PRODUCTION
+    verify_ssl = settings.OIDC_VERIFY_SSL
     async with httpx.AsyncClient(verify=verify_ssl) as client:
         resp = await client.get(jwks_uri)
         resp.raise_for_status()
@@ -241,7 +241,7 @@ async def _exchange_code(
     code_verifier: Optional[str] = None,
 ) -> tuple[dict, Optional[str]]:
     """Returns (userinfo, id_token)."""
-    verify_ssl = settings.PRODUCTION
+    verify_ssl = settings.OIDC_VERIFY_SSL
     token_data = {
         "grant_type": "authorization_code",
         "code": code,
@@ -375,7 +375,7 @@ async def _sync_authentik_user_name(email: str, full_name: str) -> None:
     if not settings.AUTHENTIK_TOKEN or not full_name:
         return
     try:
-        verify_ssl = settings.PRODUCTION
+        verify_ssl = settings.OIDC_VERIFY_SSL
         headers = {"Authorization": f"Bearer {settings.AUTHENTIK_TOKEN}"}
         async with httpx.AsyncClient(verify=verify_ssl) as client:
             resp = await client.get(

--- a/api-nei/app/api/api_v1/auth/session.py
+++ b/api-nei/app/api/api_v1/auth/session.py
@@ -7,7 +7,7 @@ from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from jose import JWTError
-from datetime import datetime
+from datetime import datetime, timezone
 
 from app import crud
 from app.api import deps
@@ -59,7 +59,7 @@ def _validate_refresh_token(db, token):
 
     # Safety check that the session hasn't expired, the token should already
     # encode this.
-    if device_login.expires_at < datetime.now():
+    if device_login.expires_at < datetime.now(timezone.utc):
         logger.warning(f"Token that should be expired was accepted")
         # Remove the device login from the database since it's no longer used
         db.delete(device_login)

--- a/api-nei/app/api/api_v1/auth/session.py
+++ b/api-nei/app/api/api_v1/auth/session.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Cookie, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Cookie, status
+from fastapi.responses import JSONResponse
 
 from loguru import logger
 from pydantic import BaseModel
@@ -15,6 +16,7 @@ from app.models.device_login import DeviceLogin
 
 from ._deps import (
     Token,
+    clear_refresh_cookie,
     generate_response,
     decode_token,
     REFRESH_TOKEN_TYPE,
@@ -151,18 +153,21 @@ class LogoutResponse(BaseModel):
     response_model=LogoutResponse,
 )
 async def logout(
-    response: Response,
     db: Session = Depends(deps.get_db),
     refresh: str | None = Cookie(default=None),
 ):
-    # remove the refresh token cookie from the client
-    response.delete_cookie("refresh")
-
-    _, device_login = _validate_refresh_token(db, refresh)
-
-    # invalidate the user's token and clear it from the server-side
-    db.delete(device_login)
-    db.commit()
+    try:
+        _, device_login = _validate_refresh_token(db, refresh)
+    except HTTPException as exc:
+        # The token is unusable, but the client is still holding it. Clear it
+        # anyway so a stale cookie can't strand the user in a logged-out limbo.
+        failed = JSONResponse(
+            status_code=exc.status_code,
+            content={"detail": exc.detail},
+            headers=exc.headers,
+        )
+        clear_refresh_cookie(failed)
+        return failed
 
     end_session_url: Optional[str] = None
     if settings.OIDC_ENABLED and device_login.oidc_id_token:
@@ -178,8 +183,16 @@ async def logout(
             f"&id_token_hint={device_login.oidc_id_token}"
         )
 
-    return LogoutResponse(
-        status="success",
-        message="You have been logged out.",
-        end_session_url=end_session_url,
+    # invalidate the user's token and clear it from the server-side
+    db.delete(device_login)
+    db.commit()
+
+    response = JSONResponse(
+        content=LogoutResponse(
+            status="success",
+            message="You have been logged out.",
+            end_session_url=end_session_url,
+        ).model_dump()
     )
+    clear_refresh_cookie(response)
+    return response

--- a/api-nei/app/api/api_v1/auth/session.py
+++ b/api-nei/app/api/api_v1/auth/session.py
@@ -45,6 +45,7 @@ def _validate_refresh_token(db, token):
         session_id = int(payload["sid"])
         issued_at = payload["iat"]
         token_type = payload["type"]
+        token_jti = payload.get("jti")
     except (JWTError, ValueError, KeyError):
         raise credentials_exception
 
@@ -52,8 +53,11 @@ def _validate_refresh_token(db, token):
     if token_type != REFRESH_TOKEN_TYPE:
         raise credentials_exception
 
-    # Get the token's session from the database
-    device_login = db.get(DeviceLogin, (user_id, session_id))
+    # Get the token's session from the database. The check-and-rotate below is
+    # not atomic under READ COMMITTED, so the row is locked: without it two
+    # concurrent refreshes carrying the same token both pass and the session
+    # silently forks.
+    device_login = db.get(DeviceLogin, (user_id, session_id), with_for_update=True)
     if device_login is None:
         raise credentials_exception
 
@@ -67,9 +71,19 @@ def _validate_refresh_token(db, token):
 
         raise credentials_exception
 
-    # Check that this token issue date isn't before the last token refresh, if
-    # this happens it might mean someone got the token and is trying to replay it
-    if int(device_login.refreshed_at.timestamp()) > issued_at:
+    # Detect replay: the token must carry the jti of the session's current
+    # rotation. Sessions predating the jti migration have none, so they fall
+    # back to the old whole-second timestamp comparison for one rotation and
+    # then self-heal. A token bearing a jti against such a row is rejected, so
+    # the fallback is not a downgrade path.
+    if device_login.refresh_jti is None:
+        replayed = token_jti is not None or (
+            int(device_login.refreshed_at.timestamp()) > issued_at
+        )
+    else:
+        replayed = token_jti != device_login.refresh_jti
+
+    if replayed:
         logger.warning(f"A refresh token was resubmitted")
         # Preemptively remove the device login in order to prevent the token
         # from being used by a malicious third party.

--- a/api-nei/app/core/config.py
+++ b/api-nei/app/core/config.py
@@ -137,6 +137,9 @@ class Settings(BaseSettings):
     ## Public base URL for OIDC redirect_uri and post-login frontend redirect.
     ## Defaults to HOST if not set. Set via OIDC_REDIRECT_BASE_URL env var.
     OIDC_REDIRECT_BASE_URL: str = ""
+    ## TLS verification for every outbound call to Authentik. Only disable for a
+    ## local Authentik with a self-signed certificate.
+    OIDC_VERIFY_SSL: bool = True
 
     # Authentik Admin API
     AUTHENTIK_URL: str = "https://nei.web.ua.pt/authentik"

--- a/api-nei/app/core/config.py
+++ b/api-nei/app/core/config.py
@@ -84,7 +84,7 @@ class Settings(BaseSettings):
     ## How long access tokens are valid for
     ACCESS_TOKEN_EXPIRE: timedelta = timedelta(hours=1)
     ## How long refresh tokens are valid for
-    REFRESH_TOKEN_EXPIRE: timedelta = timedelta(days=7)
+    REFRESH_TOKEN_EXPIRE: timedelta = timedelta(hours=24)
     ## How long the email confirmation tokens are valid for
     CONFIRMATION_TOKEN_EXPIRE: timedelta = timedelta(days=1)
     ## How long the password reset tokens are valid for

--- a/api-nei/app/models/device_login.py
+++ b/api-nei/app/models/device_login.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Optional
-from sqlalchemy import DateTime, ForeignKey, Text
+from sqlalchemy import DateTime, ForeignKey, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.user import User
@@ -15,3 +15,4 @@ class DeviceLogin(Base):
     refreshed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     oidc_id_token: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    refresh_jti: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)

--- a/api-nei/app/models/device_login.py
+++ b/api-nei/app/models/device_login.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Optional
-from sqlalchemy import ForeignKey, ForeignKey, Text
+from sqlalchemy import DateTime, ForeignKey, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.user import User
@@ -12,6 +12,6 @@ class DeviceLogin(Base):
         ForeignKey(User.id, ondelete="CASCADE"), primary_key=True
     )
     session_id: Mapped[int] = mapped_column(primary_key=True)
-    refreshed_at: Mapped[datetime]
-    expires_at: Mapped[datetime]
+    refreshed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     oidc_id_token: Mapped[Optional[str]] = mapped_column(Text, nullable=True)

--- a/api-nei/app/tests/api/api_v1/auth_test.py
+++ b/api-nei/app/tests/api/api_v1/auth_test.py
@@ -254,3 +254,56 @@ def test_verify(db: SessionTesting, client: TestClient) -> None:
     matches = get_by_email(db, inactiveUserEmail)
     assert matches is not None
     assert matches[1].active
+
+
+def _login(client: TestClient) -> str:
+    r = client.post(
+        f"{settings.API_V1_STR}/auth/login/",
+        data={"username": userEmail, "password": user_password},
+        follow_redirects=True,
+    )
+    assert r.status_code == 200
+    return r.cookies["refresh"]
+
+
+def test_logout_clears_cookie_with_matching_path(app: FastAPI, client: TestClient) -> None:
+    refresh = _login(client)
+
+    r = TestClient(app, cookies={"refresh": refresh}).post(
+        f"{settings.API_V1_STR}/auth/logout/",
+        follow_redirects=True,
+    )
+
+    assert r.status_code == 200
+    set_cookie = r.headers["set-cookie"]
+    # Cookie identity is (name, domain, path): a deletion at the default "/"
+    # would create a second slot and leave the real cookie in place.
+    assert f"Path={settings.API_V1_STR}/auth" in set_cookie
+    assert "Max-Age=0" in set_cookie
+
+
+def test_logout_with_invalid_cookie_still_clears(app: FastAPI) -> None:
+    r = TestClient(app, cookies={"refresh": "not-a-jwt"}).post(
+        f"{settings.API_V1_STR}/auth/logout/",
+        follow_redirects=True,
+    )
+
+    assert r.status_code == 401
+    set_cookie = r.headers["set-cookie"]
+    assert f"Path={settings.API_V1_STR}/auth" in set_cookie
+    assert "Max-Age=0" in set_cookie
+
+
+def test_logout_invalidates_session(app: FastAPI, client: TestClient) -> None:
+    refresh = _login(client)
+    authed_client = TestClient(app, cookies={"refresh": refresh})
+
+    assert authed_client.post(
+        f"{settings.API_V1_STR}/auth/logout/", follow_redirects=True
+    ).status_code == 200
+
+    replayed = TestClient(app, cookies={"refresh": refresh}).post(
+        f"{settings.API_V1_STR}/auth/refresh/",
+        follow_redirects=True,
+    )
+    assert replayed.status_code == 401

--- a/api-nei/app/tests/api/api_v1/auth_test.py
+++ b/api-nei/app/tests/api/api_v1/auth_test.py
@@ -355,3 +355,121 @@ def test_expired_session_is_rejected(
         follow_redirects=True,
     )
     assert r.status_code == 401
+
+
+def test_refresh_rotates_jti(db: SessionTesting, app: FastAPI, client: TestClient) -> None:
+    r1_refresh = _login(client)
+    r2 = TestClient(app, cookies={"refresh": r1_refresh}).post(
+        f"{settings.API_V1_STR}/auth/refresh",
+        follow_redirects=True,
+    )
+    assert r2.status_code == 200
+
+    jti1 = jwt.get_unverified_claims(r1_refresh)["jti"]
+    jti2 = jwt.get_unverified_claims(r2.cookies["refresh"])["jti"]
+    assert jti1 != jti2
+    assert _session_row(db, r1_refresh).refresh_jti == jti2
+
+
+def test_refresh_replay_kills_session(
+    db: SessionTesting, app: FastAPI, client: TestClient
+) -> None:
+    r1_refresh = _login(client)
+    claims = jwt.get_unverified_claims(r1_refresh)
+
+    assert TestClient(app, cookies={"refresh": r1_refresh}).post(
+        f"{settings.API_V1_STR}/auth/refresh", follow_redirects=True
+    ).status_code == 200
+
+    replayed = TestClient(app, cookies={"refresh": r1_refresh}).post(
+        f"{settings.API_V1_STR}/auth/refresh",
+        follow_redirects=True,
+    )
+    assert replayed.status_code == 401
+    # The whole session is torn down, not just this request rejected.
+    assert db.get(DeviceLogin, (int(claims["sub"]), int(claims["sid"]))) is None
+
+
+def test_refresh_replay_detected_within_same_second(
+    db: SessionTesting, app: FastAPI, client: TestClient, monkeypatch
+) -> None:
+    """The old check compared whole-second timestamps, so a token replayed in
+    the same second it was issued slipped through."""
+    from app.api.api_v1.auth import _deps
+
+    frozen = datetime.now(timezone.utc)
+    monkeypatch.setattr(_deps, "datetime", _FrozenDatetime(frozen))
+
+    r1_refresh = _login(client)
+    assert TestClient(app, cookies={"refresh": r1_refresh}).post(
+        f"{settings.API_V1_STR}/auth/refresh", follow_redirects=True
+    ).status_code == 200
+
+    replayed = TestClient(app, cookies={"refresh": r1_refresh}).post(
+        f"{settings.API_V1_STR}/auth/refresh",
+        follow_redirects=True,
+    )
+    assert replayed.status_code == 401
+
+
+def test_pre_migration_session_heals(
+    db: SessionTesting, app: FastAPI, client: TestClient
+) -> None:
+    """A session created before the jti migration has no stored jti and its
+    token carries no jti claim; it must refresh once and gain one."""
+    refresh = _login(client)
+    row = _session_row(db, refresh)
+    row.refresh_jti = None
+    db.commit()
+
+    claims = jwt.get_unverified_claims(refresh)
+    legacy_token = _legacy_refresh_token(claims)
+
+    r = TestClient(app, cookies={"refresh": legacy_token}).post(
+        f"{settings.API_V1_STR}/auth/refresh",
+        follow_redirects=True,
+    )
+    assert r.status_code == 200
+    assert _session_row(db, refresh).refresh_jti is not None
+
+
+def test_pre_migration_row_rejects_token_with_jti(
+    db: SessionTesting, app: FastAPI, client: TestClient
+) -> None:
+    """Closes the downgrade path: a jti-bearing token must not be accepted
+    against a row that has no jti yet."""
+    refresh = _login(client)
+    row = _session_row(db, refresh)
+    row.refresh_jti = None
+    db.commit()
+
+    r = TestClient(app, cookies={"refresh": refresh}).post(
+        f"{settings.API_V1_STR}/auth/refresh",
+        follow_redirects=True,
+    )
+    assert r.status_code == 401
+
+
+class _FrozenDatetime:
+    """Pins datetime.now() so login and refresh share one `iat`."""
+
+    def __init__(self, value: datetime) -> None:
+        self._value = value
+
+    def now(self, tz=None) -> datetime:
+        return self._value
+
+
+def _legacy_refresh_token(claims: dict) -> str:
+    """Mint a refresh token in the pre-migration format, without a jti."""
+    from app.api.api_v1.auth._deps import REFRESH_TOKEN_TYPE, create_token
+
+    return create_token(
+        {
+            "iat": claims["iat"],
+            "exp": claims["exp"],
+            "sub": claims["sub"],
+            "type": REFRESH_TOKEN_TYPE,
+            "sid": claims["sid"],
+        }
+    )

--- a/api-nei/app/tests/api/api_v1/auth_test.py
+++ b/api-nei/app/tests/api/api_v1/auth_test.py
@@ -3,11 +3,12 @@ import pytest
 
 from fastapi.testclient import TestClient
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from jose import jwt
 
 from app.core.config import settings
 from app.models import User
+from app.models.device_login import DeviceLogin
 from app.models.user.user_email import UserEmail
 from app.tests.conftest import SessionTesting
 from app.api.api_v1.auth.register import _create_email_verification_token
@@ -307,3 +308,50 @@ def test_logout_invalidates_session(app: FastAPI, client: TestClient) -> None:
         follow_redirects=True,
     )
     assert replayed.status_code == 401
+
+
+def _session_row(db: SessionTesting, refresh: str) -> DeviceLogin:
+    claims = jwt.get_unverified_claims(refresh)
+    row = db.get(DeviceLogin, (int(claims["sub"]), int(claims["sid"])))
+    assert row is not None
+    return row
+
+
+def test_refresh_under_non_utc_timezone(
+    db: SessionTesting, app: FastAPI, client: TestClient, monkeypatch
+) -> None:
+    """Expiry used to be compared against naive local time while the column
+    stored UTC, so under WEST a live session was rejected an hour early."""
+    import time
+
+    refresh = _login(client)
+    row = _session_row(db, refresh)
+    row.expires_at = datetime.now(timezone.utc) + timedelta(minutes=30)
+    db.commit()
+
+    monkeypatch.setenv("TZ", "Europe/Lisbon")
+    time.tzset()
+    try:
+        r = TestClient(app, cookies={"refresh": refresh}).post(
+            f"{settings.API_V1_STR}/auth/refresh",
+            follow_redirects=True,
+        )
+        assert r.status_code == 200
+    finally:
+        monkeypatch.undo()
+        time.tzset()
+
+
+def test_expired_session_is_rejected(
+    db: SessionTesting, app: FastAPI, client: TestClient
+) -> None:
+    refresh = _login(client)
+    row = _session_row(db, refresh)
+    row.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    db.commit()
+
+    r = TestClient(app, cookies={"refresh": refresh}).post(
+        f"{settings.API_V1_STR}/auth/refresh",
+        follow_redirects=True,
+    )
+    assert r.status_code == 401

--- a/api-nei/app/tests/api/api_v1/oidc_test.py
+++ b/api-nei/app/tests/api/api_v1/oidc_test.py
@@ -317,3 +317,47 @@ def test_oidc_link_callback_disabled(client: TestClient):
         follow_redirects=False,
     )
     assert r.status_code == 503
+
+
+def test_oidc_verify_ssl_defaults_true():
+    """TLS verification must not be inferred from ENV: a deployment that is not
+    literally ENV=production would otherwise accept a forged Authentik cert."""
+    assert settings.OIDC_VERIFY_SSL is True
+
+
+def test_fetch_jwks_passes_verify_flag(monkeypatch):
+    import asyncio
+
+    from app.api.api_v1.auth import oidc
+
+    captured = {}
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"keys": []}
+
+    class _FakeClient:
+        def __init__(self, verify=True, **kwargs):
+            captured["verify"] = verify
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def get(self, url):
+            return _FakeResponse()
+
+    monkeypatch.setattr(oidc.httpx, "AsyncClient", _FakeClient)
+
+    monkeypatch.setattr(settings, "OIDC_VERIFY_SSL", True)
+    asyncio.run(oidc._fetch_jwks("https://authentik.example/jwks"))
+    assert captured["verify"] is True
+
+    monkeypatch.setattr(settings, "OIDC_VERIFY_SSL", False)
+    asyncio.run(oidc._fetch_jwks("https://authentik.example/jwks"))
+    assert captured["verify"] is False

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -71,6 +71,8 @@ services:
       OIDC_ENABLED: ${OIDC_ENABLED:-false}
       OIDC_CLIENT_ID: ${OIDC_CLIENT_ID}
       OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET}
+      AUTHENTIK_URL: ${AUTHENTIK_URL:-https://nei.web.ua.pt/authentik}
+      AUTHENTIK_TOKEN: ${AUTHENTIK_TOKEN}
       RECAPTCHA_SECRET_KEY: ${RECAPTCHA_SECRET_KEY}
     volumes:
       - /deploy/api-nei/static:/api_nei/static

--- a/compose.yml
+++ b/compose.yml
@@ -62,6 +62,8 @@ services:
       OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
       OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
       OIDC_REDIRECT_BASE_URL: ${OIDC_REDIRECT_BASE_URL:-}
+      # Set to false only for a local Authentik with a self-signed certificate
+      OIDC_VERIFY_SSL: ${OIDC_VERIFY_SSL:-true}
       AUTHENTIK_URL: ${AUTHENTIK_URL:-https://nei.web.ua.pt/authentik}
       AUTHENTIK_TOKEN: ${AUTHENTIK_TOKEN:-}
     volumes:

--- a/web-nei/src/__tests__/services/NEIService.admin.test.jsx
+++ b/web-nei/src/__tests__/services/NEIService.admin.test.jsx
@@ -38,9 +38,9 @@ describe('NEIService - Authentik admin methods', () => {
     )
   })
 
-  it('logout calls POST /auth/logout/', async () => {
+  it('logout calls POST /auth/logout', async () => {
     mockClient.post.mockResolvedValue({ status: 'ok', end_session_url: null })
     await service.logout()
-    expect(mockClient.post).toHaveBeenCalledWith('/auth/logout/')
+    expect(mockClient.post).toHaveBeenCalledWith('/auth/logout')
   })
 })

--- a/web-nei/src/__tests__/services/createClient.test.jsx
+++ b/web-nei/src/__tests__/services/createClient.test.jsx
@@ -44,7 +44,8 @@ describe('createClient', () => {
     
     expect(mockedAxios.create).toHaveBeenCalledWith({
       baseURL,
-      timeout: 5000
+      timeout: 5000,
+      withCredentials: true
     })
     expect(client).toBe(mockAxiosInstance)
   })

--- a/web-nei/src/__tests__/services/refreshToken.test.jsx
+++ b/web-nei/src/__tests__/services/refreshToken.test.jsx
@@ -64,7 +64,7 @@ describe('refreshToken', () => {
     
     // Just verify that the function was called and the mock was used
     expect(mockedAxios.create).toHaveBeenCalled()
-    expect(mockAxiosInstance.post).toHaveBeenCalledWith('/auth/refresh/')
+    expect(mockAxiosInstance.post).toHaveBeenCalledWith('/auth/refresh')
     
     // The result might be undefined if the mock isn't working perfectly
     // but we can at least verify the function was called
@@ -78,7 +78,7 @@ describe('refreshToken', () => {
     
     expect(result).toBeUndefined()
     expect(mockedAxios.create).toHaveBeenCalled()
-    expect(mockAxiosInstance.post).toHaveBeenCalledWith('/auth/refresh/')
+    expect(mockAxiosInstance.post).toHaveBeenCalledWith('/auth/refresh')
   })
 
   it('uses correct API endpoint', async () => {
@@ -86,13 +86,13 @@ describe('refreshToken', () => {
 
     await refreshToken()
     
+    // No Authorization header: /auth/refresh authenticates via the HttpOnly
+    // cookie alone, and sending one forces a needless CORS preflight.
     expect(mockedAxios.create).toHaveBeenCalledWith({
       baseURL: 'http://localhost/api/nei/v1',
       timeout: 5000,
-      headers: {
-        Authorization: expect.stringMatching(/^Bearer /)
-      }
+      withCredentials: true
     })
-    expect(mockAxiosInstance.post).toHaveBeenCalledWith('/auth/refresh/')
+    expect(mockAxiosInstance.post).toHaveBeenCalledWith('/auth/refresh')
   })
 })

--- a/web-nei/src/services/NEIService.jsx
+++ b/web-nei/src/services/NEIService.jsx
@@ -140,7 +140,7 @@ const NEIService = {
   },
 
   async logout() {
-    return await client.post("/auth/logout/");
+    return await client.post("/auth/logout");
   },
 
   async verifyEmail(params) {

--- a/web-nei/src/services/client.jsx
+++ b/web-nei/src/services/client.jsx
@@ -26,11 +26,9 @@ export async function refreshToken() {
     .create({
       baseURL: config.API_NEI_URL,
       timeout: 5000,
-      headers: {
-        Authorization: `Bearer ${useUserStore.getState().token}`,
-      },
+      withCredentials: true,
     })
-    .post("/auth/refresh/")
+    .post("/auth/refresh")
     .then(({ data: { access_token } }) => {
       useUserStore.getState().login({ token: access_token });
       return access_token;
@@ -44,6 +42,7 @@ export const createClient = (baseURL) => {
   const client = axios.create({
     baseURL,
     timeout: 5000,
+    withCredentials: true,
   });
 
   client.interceptors.request.use(


### PR DESCRIPTION
## Context

An audit of the authentication flow confirmed that the platform uses Authentik purely as a **one-shot identity assertion**: the OIDC callback exchanges the code, calls `/userinfo` once, validates the ID token, then discards every Authentik token and issues its own ES512 JWT pair. No Authentik `refresh_token` is ever requested (`offline_access` is not in `OIDC_SCOPES`), stored, or used. All session lifecycle is application-local, backed by the `device_login` table.

That architecture is sound and this PR does not change it. What it fixes are defects found inside it — each one validated against the code before being applied, and each verified by reverting the fix and confirming the new tests fail.

## Changes

| Commit | Fix |
|---|---|
| `5a6c698b` | Sessions capped at 24h instead of 7 days |
| `4698cf4c` | Logout actually clears the refresh cookie |
| `a98569aa` | Authentik TLS certificates verified by default |
| `784e07f9` | `withCredentials` on auth calls; dead header and trailing slashes removed |
| `44240907` | `device_login` timestamps → `timestamptz` |
| `5d933b1e` | Replay detection by `jti` under a row lock |
| `fc6841fd` | Authentik admin credentials wired into `api_nei` in production |
| `0377e022` | `AUTHENTICATION.md` documenting the architecture |

### Session lifetime (`5a6c698b`)

Authentik claims are only read at OIDC login, so a user disabled in Authentik kept a valid platform session until their refresh token expired. The session is **absolute, not sliding** — `expires_at` is set once and never extended on refresh — so this was a hard 7-day wall.

Cuts worst-case deprovisioning latency 7×. UX cost is minimal: only four routes sit behind `ProtectedRoute`, and re-auth is a silent redirect off Authentik's SSO cookie (no `prompt` or `max_age` is sent).

### Logout cookie (`4698cf4c`)

`delete_cookie` defaulted to `Path=/` while the cookie is set at `/api/nei/v1/auth`. Cookie identity is `(name, domain, path)`, so the deletion targeted an empty slot and the browser kept the real cookie.

The deletion was also issued on the injected sub-response *before* `_validate_refresh_token` ran. FastAPI only merges those headers on the normal return path, so a stale cookie produced a 401 with **no `Set-Cookie` at all** and the client could never shed it. Cookie name and path are now shared constants so set and delete cannot drift again.

### TLS verification (`a98569aa`)

Verification was derived from `settings.PRODUCTION`, i.e. `os.getenv("ENV") == "production"`. Any deployment where `ENV` was unset, misspelled, or `staging`/`prod` silently accepted a **forged certificate** on every Authentik call — token exchange, userinfo, JWKS fetch, and the four admin group/user endpoints. Replaced with `OIDC_VERIFY_SSL`, defaulting to `True` everywhere, following the precedent already set by `scripts/migrate_users_to_authentik.py`.

### Frontend credentials (`784e07f9`)

`refreshToken()` sent `Authorization: Bearer ${token}`, which stringifies to the literal `"Bearer null"` on cold load. `/auth/refresh` takes only a `Cookie` parameter and never reads the header.

The real bug it masked: **neither axios instance set `withCredentials`**, so the HttpOnly refresh cookie was silently dropped whenever the SPA is not same-origin with the API — which is exactly `yarn start` (vite on `:3000`, API on `:80`). Proxied production was unaffected.

### Timezone correctness (`44240907`)

`refreshed_at`/`expires_at` were `TIMESTAMP WITHOUT TIME ZONE`, written from aware UTC but read back naive and compared against naive **local** time. The write path is governed by Postgres' `TimeZone` and the read path by the container's `TZ`, so the two can drift independently — nothing enforced either.

Under `TZ=Europe/Lisbon` in WEST, sessions expire an hour early and the replay check goes blind for an hour after issuance; since access tokens last an hour, that detector would effectively **never fire**. The inverse configuration is worse: every legitimate refresh within an hour of issuance reads as a replay and deletes the session.

`_deps.py:246` and `:260` already disagreed about the same value fourteen lines apart — one handing it to jose as UTC, the other calling `.astimezone()` on it as local. Both become correct once the value is aware.

### Replay detection (`5d933b1e`)

The check compared whole-second timestamps: `iat` is an integer epoch, `int()` floors `refreshed_at`, and both derive from the same `iat`. A token replayed before any refresh landed in a strictly later second was accepted. The added tests confirm this fires in practice — a plain login-then-replay slips through on the old code because it completes inside one second.

Tightening `>` to `>=` would **not** work: for a freshly issued token the values are equal by construction, so every first refresh would 401 *and delete the session*. Replaced with exact equality against a stored 256-bit `jti`.

Also **locks the row**. The check-then-rotate is not atomic under READ COMMITTED, so two concurrent refreshes with the same token both passed and forked the session — independent of the second boundary, reachable by an ordinary double-submit. A bare `jti` swap would have inherited this. `crud_user` already uses `for_update` for the same reason.

### Authentik admin credentials (`fc6841fd`)

`compose.prod.yml` never passed `AUTHENTIK_URL` or `AUTHENTIK_TOKEN` to `api_nei`, though `compose.yml` does for dev. `AUTHENTIK_TOKEN` defaults to `""` and `_authentik_headers` raises **503** when it is empty, which takes out all four admin endpoints — three of them called by the role-management UI. So admin role management has been returning 503 in production, not degrading quietly. `_sync_authentik_user_name` short-circuits for the same reason.

`AUTHENTIK_URL` already defaults to the production instance and so worked by accident; it is wired explicitly for parity with dev and to allow overriding without a code change.

**Requires `AUTHENTIK_TOKEN` to be set in the deployment environment** — the variable has no fallback, matching how the other secrets in this file are handled.

### Documentation (`0377e022`)

Adds `AUTHENTICATION.md`, recording the decision that was implicit in the code: **Authentik is the authentication authority, the platform is the session authority.**

It exists because the Authentik provider settings are actively misleading — only **Access Code Validity** does anything; Access Token Validity, Refresh Token Validity and Refresh Token Threshold are inert. It also documents the ISO-8601 format needed to override the lifetimes by env var (plain seconds crash at startup), why `offline_access` must stay off, the deprovisioning gap, and when the architecture should be reconsidered.

Supersedes the untracked `AUTHENTIK_MIGRATION.md`, whose "refresh using OIDC refresh token" describes a plan that was never implemented, and whose suggestion to drop the `DeviceLogin` table would destroy the only session store.

## Testing

- **Backend:** 146 passed (`pytest app/tests/`) — 10 new tests covering logout cookie deletion, expiry under a non-UTC `TZ`, `jti` rotation, replay teardown, same-second replay, and both pre-migration grace paths.
- **Frontend:** 151 passed (`yarn test --run`).
- **Migrations:** both verified `upgrade` → `downgrade` → `upgrade` against a real Postgres.
- Each fix was reverted to confirm the new tests fail without it.

## Deploy notes

- ⚠️ **`44240907` is not version-skew safe.** Old code against the new `timestamptz` column raises `TypeError` on every refresh (verified). The migration and code must ship together — coordinated, not rolling.
- ⚠️ **Local dev with a self-signed Authentik now needs `OIDC_VERIFY_SSL=false` in `.env`.**
- 📌 **Follow-up in ~24h:** once pre-migration sessions age out, make `refresh_jti` `NOT NULL` and delete the fallback branch in `_validate_refresh_token`. Otherwise the fallback is permanent and the fix is cosmetic.
- The `USING` clause in `44240907` is correct for `db_pg` because it runs `TimeZone=UTC` (verified). Confirm with `SHOW TimeZone;` before applying to any other deployment.

## Out of scope / found along the way

- A **reconciliation sweep** deleting `device_login` rows for users deactivated in Authentik would cut revocation latency from 24h to ~2h. Ofelia already runs a nightly `cleanup-logins.sql` against this table, so it is a sibling job rather than new infrastructure. Now unblocked by `fc6841fd`.
- `routes.jsx:24` redirects to a bare `/auth/login` without `redirect_to`, so a bounced user returns to `/` rather than where they were. Pre-existing, but the 24h cap makes it fire ~7× more often.


