### PR TITLE
Potential fix for code scanning alert no. 13: Clear-text logging of sensitive information

### DIFF
--- a/api-nei/app/api/api_v1/auth/token.py
+++ b/api-nei/app/api/api_v1/auth/token.py
@@ -69,7 +69,7 @@ async def get_token(
         if oauth_token not in tokens:
             raise HTTPException(status_code=404, detail="Token not found")
 
-        print(oauth_verifier, oauth_token, tokens[oauth_token])
+        logger.debug("OAuth callback received; proceeding with access token exchange.")
 
         # Step 3: Access Token
         oauth = AsyncOAuth1Client(
@@ -80,7 +80,7 @@ async def get_token(
             verifier=oauth_verifier,
         )
         oauth_tokens = await oauth.fetch_access_token(access_token_url)
-        print(oauth_tokens)
+        logger.debug("Access token fetched successfully from IdP.")
         token = oauth_tokens.get("oauth_token")
         token_secret = oauth_tokens.get("oauth_token_secret")
         data = await get_data(token, token_secret, scopes=["name", "uu"])
@@ -134,9 +134,9 @@ async def get_data(token, token_secret, scopes):
     data = {}
     for s in scopes:
         res = await oauth.get(f"{get_data_url}?scope={s}&format=json")
-        print(res, token, token_secret, scopes)
+        logger.debug(f"Fetched data from IdP for scope '{s}'.")
         res = res.json()
-        print(res)
+        logger.debug(f"Received response payload for scope '{s}' with keys: {list(res.keys()) if isinstance(res, dict) else 'non-dict payload'}")
         if s == "student_info":
             data["student_info"] = res["NewDataSet"]["ObterDadosAluno"]
         elif s == "student_courses":


### PR DESCRIPTION
Potential fix for [https://github.com/NEI-AAUAV/Platform/security/code-scanning/13](https://github.com/NEI-AAUAV/Platform/security/code-scanning/13)

To fix this without changing functionality, remove sensitive values from logging/printing and keep only non-sensitive operational context. Specifically in `api-nei/app/api/api_v1/auth/token.py`:

- Replace debug `print(...)` calls that include OAuth tokens/secrets (or full token response objects) with safe `logger.debug(...)` messages that do not include secret contents.
- Keep business logic unchanged (token exchange, DB operations, response generation).
- No new dependency is needed since `loguru.logger` is already imported.

Best single approach here:
1. Replace line 72 print with a message that only indicates callback was received.
2. Replace line 83 print of `oauth_tokens` with a generic success debug message.
3. Replace line 137 print of `res, token, token_secret, scopes` with scoped status logging only.
4. Replace line 139 print of full response JSON with a minimal/non-sensitive summary (e.g., keys), avoiding payload dumps that may include PII.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
